### PR TITLE
feat: allow TimeOfDay comparison against string

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ or
 rule 'Log an entry if started between 3:30:04 and midnight using TimeOfDay objects' do
   on_start
   run { logger.info ("Started at #{TimeOfDay.now}")}
-  between TimeOfDay.new(h: 3, m: 30, s: 4)..TimeOfDay.midnight
+  between TimeOfDay.new(h: 3, m: 30, s: 4)..TimeOfDay.MIDNIGHT
 end
 ```
 
@@ -1471,6 +1471,37 @@ after 3.seconds do |timer|
   logger.info("Timer Fired")
   timer.reschedule 5.seconds
 end
+```
+
+### TimeOfDay
+
+TimeOfDay class can be used in rules for time related logic. Methods:
+
+| Method      | Parameter | Description                                                 | Example                                                  |
+| ----------- | --------- | ----------------------------------------------------------- | -------------------------------------------------------- |
+| parse       | String    | Creates a TimeOfDay object with a given time string.        | curfew_start = TimeOfDay.parse '19:30'                   |
+| now         |           | Creates a TimeOfDay object that represents the current time | TimeOfDay.now > curfew_start, or TimeOfDay.now > '19:30' |
+| MIDNIGHT    |           | Creates a TimeOfDay object for 00:00                        | TimeOfDay.MIDNIGHT                                       |
+| NOON        |           | Creates a TimeOfDay object for 12:00                        | TimeOfDay.now < TimeOfDay.NOON                           |
+| constructor | h, m, s   | Creates a TimeOfDay with the given hour, minute, second     | TimeOfDay.new(h: 17, m: 30, s: 0)                        |
+| hour        |           | Returns the hour part of the object                         | TimeOfDay.now.hour                                       |
+| minute      |           | Returns the minute part of the object                       | TimeOfDay.now.minute                                     |
+| second      |           | Returns the second part of the object                       | TimeOfDay.now.second                                     |
+
+A TimeOfDay object can be compared against another TimeOfDay object or a parseable string representation of time.
+
+#### Examples
+
+```ruby
+#Create a TimeOfDay object
+break_time = TimeOfDay.NOON
+
+if TimeOfDay.now > TimeOfDay.new(h: 17, m: 30, s: 0) # comparing two TimeOfDay objects
+  # do something
+elsif TimeOfDay.now < '8:30' # comparison against a string
+  #do something
+end
+four_pm = TimeOfDay.parse '16:00'
 ```
 
 

--- a/features/time_of_day.feature
+++ b/features/time_of_day.feature
@@ -1,0 +1,18 @@
+Feature:  Rule languages supports comparing using TimeOfDay
+
+    Background:
+        Given Clean OpenHAB with latest Ruby Libraries
+
+    Scenario Outline: Between guards accept strings to guard rule execution based on time of day
+        Given a rule template:
+            """
+        if TimeOfDay.now < <template_time>
+          logger.info("Time of day compare succeded")
+        end
+            """
+        When I deploy the rule
+        Then It <should> log "Time of day compare succeded" within 5 seconds
+        Examples:
+            | template_time                                   | should     |
+            | '<%=(Time.now + (5*60)).strftime('%H:%M:%S')%>' | should     |
+            | '<%=(Time.now - (5*60)).strftime('%H:%M:%S')%>' | should not |

--- a/lib/openhab/core/dsl/time_of_day.rb
+++ b/lib/openhab/core/dsl/time_of_day.rb
@@ -109,6 +109,7 @@ module OpenHAB
           # @since 0.0.1
           # @return [Number, nil] -1,0,1 if other TimeOfDay is less than, equal to, or greater than this TimeOfDay or nil if an object other than TimeOfDay is provided
           def <=>(other)
+            other = self.class.parse(other) if other.is_a? String
             return unless other.is_a? TimeOfDay
 
             @local_time.compare_to(other.local_time)


### PR DESCRIPTION
Allows the following code

```ruby
if TimeOfDay.now < '15:00'
#do something
end
```

Update README.md