### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ openhab.code-workspace
 /.idea/
 .java-verison
 .ruby-version
+Gemfile.lock


### PR DESCRIPTION
Gemfile.lock keeps coming up on my system. This PR excludes it.