### PR TITLE
feat: TimeOfDay.parse understands am/pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1477,16 +1477,16 @@ end
 
 TimeOfDay class can be used in rules for time related logic. Methods:
 
-| Method      | Parameter | Description                                                 | Example                                                  |
-| ----------- | --------- | ----------------------------------------------------------- | -------------------------------------------------------- |
-| parse       | String    | Creates a TimeOfDay object with a given time string.        | curfew_start = TimeOfDay.parse '19:30'                   |
-| now         |           | Creates a TimeOfDay object that represents the current time | TimeOfDay.now > curfew_start, or TimeOfDay.now > '19:30' |
-| MIDNIGHT    |           | Creates a TimeOfDay object for 00:00                        | TimeOfDay.MIDNIGHT                                       |
-| NOON        |           | Creates a TimeOfDay object for 12:00                        | TimeOfDay.now < TimeOfDay.NOON                           |
-| constructor | h, m, s   | Creates a TimeOfDay with the given hour, minute, second     | TimeOfDay.new(h: 17, m: 30, s: 0)                        |
-| hour        |           | Returns the hour part of the object                         | TimeOfDay.now.hour                                       |
-| minute      |           | Returns the minute part of the object                       | TimeOfDay.now.minute                                     |
-| second      |           | Returns the second part of the object                       | TimeOfDay.now.second                                     |
+| Method      | Parameter | Description                                                                                                                                             | Example                                                                                                                                                      |
+| ----------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| parse       | String    | Creates a TimeOfDay object with a given time string. The format is hh[:mm[:ss]][am\|pm]. When am/pm is not specified, the time should be in 24h format. | curfew_start = TimeOfDay.parse '19:30' => 19:30<br/>TimeOfDay.parse '2pm' => 14:00<br/> TimeOfDay.parse '12:30am' => 00:30<br/>TimeOfDay.parse '15' => 15:00 |
+| now         |           | Creates a TimeOfDay object that represents the current time                                                                                             | TimeOfDay.now > curfew_start, or TimeOfDay.now > '19:30'                                                                                                     |
+| MIDNIGHT    |           | Creates a TimeOfDay object for 00:00                                                                                                                    | TimeOfDay.MIDNIGHT                                                                                                                                           |
+| NOON        |           | Creates a TimeOfDay object for 12:00                                                                                                                    | TimeOfDay.now < TimeOfDay.NOON                                                                                                                               |
+| constructor | h, m, s   | Creates a TimeOfDay with the given hour, minute, second                                                                                                 | TimeOfDay.new(h: 17, m: 30, s: 0)                                                                                                                            |
+| hour        |           | Returns the hour part of the object                                                                                                                     | TimeOfDay.now.hour                                                                                                                                           |
+| minute      |           | Returns the minute part of the object                                                                                                                   | TimeOfDay.now.minute                                                                                                                                         |
+| second      |           | Returns the second part of the object                                                                                                                   | TimeOfDay.now.second                                                                                                                                         |
 
 A TimeOfDay object can be compared against another TimeOfDay object or a parseable string representation of time.
 

--- a/features/time_of_day.feature
+++ b/features/time_of_day.feature
@@ -16,3 +16,29 @@ Feature:  Rule languages supports comparing using TimeOfDay
             | template_time                                   | should     |
             | '<%=(Time.now + (5*60)).strftime('%H:%M:%S')%>' | should     |
             | '<%=(Time.now - (5*60)).strftime('%H:%M:%S')%>' | should not |
+
+
+    Scenario Outline: Parse strings into a TimeOfDay object
+        Given a rule template:
+            """
+            parsed = TimeOfDay.parse <template_time>
+            tod = TimeOfDay.new(h: <h>, m: <m>, s: <s>)
+            if parsed == tod
+                logger.info("TimeOfDay parser is correct")
+            end
+            """
+        When I deploy the rule
+        Then It <should> log "TimeOfDay parser is correct" within 2 seconds
+        Examples:
+            | template_time | h  | m  | s  | should     |
+            | '1'           | 1  | 0  | 0  | should     |
+            | '02'          | 2  | 0  | 0  | should     |
+            | '1pm'         | 13 | 0  | 0  | should     |
+            | '12:30'       | 12 | 30 | 0  | should     |
+            | '12 am'       | 0  | 0  | 0  | should     |
+            | '7:00 AM'     | 7  | 0  | 0  | should     |
+            | '7:00 pm'     | 19 | 0  | 0  | should     |
+            | '7:30:20am'   | 7  | 30 | 20 | should     |
+            | '12  am'      | 0  | 0  | 0  | should not |
+            | '17:00pm'     | 17 | 0  | 0  | should not |
+            | '17:00am'     | 17 | 0  | 0  | should not |

--- a/lib/openhab/core/dsl/time_of_day.rb
+++ b/lib/openhab/core/dsl/time_of_day.rb
@@ -10,6 +10,7 @@ module OpenHAB
       # @since 0.0.1
       module Tod
         java_import java.time.LocalTime
+        java_import java.time.format.DateTimeFormatter
 
         # Class that encapsulates a Time of Day, often viewed as hour-minute-second
         # @author Brian O'Connell
@@ -45,16 +46,11 @@ module OpenHAB
 
           # Constructs a TimeOfDay representing the time when called
           # @since 0.0.1
-          # @param [String] String representation of TimeOfDay. Valid formats include "HH:MM:SS", "HH:MM", "H:MM", "HH", "H"
+          # @param [String] String representation of TimeOfDay. Valid formats include "HH:MM:SS", "HH:MM", "H:MM", "HH", "H", "H:MM am"
           # @return [TimeOfDay] Representing supplied string
           def self.parse(string)
-            # Support single digit hours
-            hour, minute, second = string.split(':')
-            hour = hour.rjust(2, '0') # Prepend zeros if necessary
-            minute ||= '00' # Create minutes if necessary to support format "HH" or "H"
-            adjusted_string = [hour, minute, second].compact.join(':') # "Put back together in format HH:MM[:SS]"
-
-            local_time = LocalTime.parse(adjusted_string)
+            format = /(am|pm)$/i.match?(string) ? 'h[:mm[:ss]][ ]a' : 'H[:mm[:ss]]'
+            local_time = LocalTime.parse(string.downcase, DateTimeFormatter.ofPattern(format))
             TimeOfDay.new(h: local_time.hour, m: local_time.minute, s: local_time.second)
           end
 


### PR DESCRIPTION
This will make TimeOfDay.parse accept '7pm', '7 pm', '7:00pm', and '7 PM' as 19:00. The check is delegated to Java's DateTimeFormatter, so '13pm' will raise an error.
