### PR TITLE
fix: TimeOfDay.parse am/pm case insensitive

### DIFF
--- a/lib/openhab/core/dsl/time_of_day.rb
+++ b/lib/openhab/core/dsl/time_of_day.rb
@@ -13,7 +13,8 @@ module OpenHAB
       # @since 0.0.1
       module Tod
         java_import java.time.LocalTime
-        java_import java.time.format.DateTimeFormatter
+        java_import java.time.format.DateTimeFormatterBuilder
+        java_import java.util.Locale
 
         # Class that encapsulates a Time of Day, often viewed as hour-minute-second
         # @author Brian O'Connell
@@ -53,7 +54,8 @@ module OpenHAB
           # @return [TimeOfDay] Representing supplied string
           def self.parse(string)
             format = /(am|pm)$/i.match?(string) ? 'h[:mm[:ss]][ ]a' : 'H[:mm[:ss]]'
-            local_time = LocalTime.parse(string.downcase, DateTimeFormatter.ofPattern(format))
+            local_time = LocalTime.parse(string, DateTimeFormatterBuilder.new
+              .parseCaseInsensitive.appendPattern(format).toFormatter(Locale::ENGLISH))
             TimeOfDay.new(h: local_time.hour, m: local_time.minute, s: local_time.second)
           rescue java.time.format.DateTimeParseException => e
             raise ArgumentError, e.message


### PR DESCRIPTION
DateTimeFormatter uses the system Locale. US Locale needs upper case AM/PM whilst some other locale need lowercase am/pm. This PR creates a DateTimeFormatter that is case insensitive.