### PR TITLE
fix: inject event.item for group update trigger

### DIFF
--- a/features/patched.feature
+++ b/features/patched.feature
@@ -1,0 +1,32 @@
+Feature:  Temporary patches
+
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
+    And groups:
+      | name         | group |
+      | Temperatures |       |
+    And items:
+      | type   | name            | label                   | state | groups       |
+      | Number | Livingroom_Temp | Living Room temperature | 70    | Temperatures |
+      | Number | Bedroom_Temp    | Bedroom temperature     | 50    | Temperatures |
+      | Number | Den_Temp        | Den temperature         | 30    | Temperatures |
+
+
+  Scenario: Group update trigger has event.item in run block
+    Given code in a rules file
+      """
+      rule 'group member updated' do
+        updated Temperatures.items
+        run do |event|
+          logger.info("event.item is #{event.item.name}")
+        end
+      end
+
+      rule 'update a group member' do
+        on_start
+        run { Livingroom_Temp.update 65 }
+      end
+      """
+    When I deploy the rules file
+    Then It should log 'event.item is Livingroom_Temp' within 5 seconds
+

--- a/lib/openhab/core/dsl/rule/item.rb
+++ b/lib/openhab/core/dsl/rule/item.rb
@@ -97,6 +97,7 @@ module OpenHAB
           #
           def updated(*items, to: nil)
             items.flatten.each do |item|
+              item = item.group if item.is_a? Group
               logger.trace("Creating updated trigger for item(#{item}) to(#{to})")
               [to].flatten.each do |to_state|
                 case item

--- a/lib/openhab/core/dsl/rule/rule.rb
+++ b/lib/openhab/core/dsl/rule/rule.rb
@@ -317,7 +317,15 @@ module OpenHAB
               when RuleConfig::Run
 
                 event = inputs&.dig('event')
-
+                # Patch event to include event.item when it doesn't exist
+                # This is to patch a bug see https://github.com/boc-tothefuture/openhab-jruby/issues/75
+                # It may be fixed in the openhab core in the future, in which case, this patch will no longer be necessary
+                unless event.nil? || defined?(event.item)
+                  class << event
+                    attr_accessor :item
+                  end
+                  event.item = inputs&.dig('triggeringItem')
+                end
                 logger.trace { "Executing rule '#{name}' run block with event(#{event})" }
                 task.block.call(event)
               when RuleConfig::Trigger


### PR DESCRIPTION
Fix #75 

This would be a temporary patch, until openhab core would fix it. 
I will look into the openhab-core code and see if I can submit a fix there too, and if it is accepted, I will revert this patch. I just don't know whether it will be accepted as they're stricter there

WDYT?