### PR TITLE
docs: timer.execution_time

### DIFF
--- a/docs/usage/misc/timers.md
+++ b/docs/usage/misc/timers.md
@@ -20,13 +20,14 @@ After method parameters
 Timer Object
 The timer object has all of the methods of the [OpenHAB Timer](https://www.openhab.org/docs/configuration/actions.html#timers) with a change to the reschedule method to enable it to operate Ruby context. The following methods are available to a Timer object:
 
-| Method        | Parameter | Description                                                                                      |
-| ------------- | --------- | ------------------------------------------------------------------------------------------------ |
-| `cancel`      |           | Cancel the scheduled timer                                                                       |
-| `reschedule`  | duration  | Optional [duration](#Duration) if unspecified original duration supplied to after method is used |
-| `active?`     |           | An alias for `Timer::isActive()`                                                                 |
-| `running?`    |           | An alias for `Timer::isRunning()`                                                                |
-| `terminated?` |           | An alias for `Timer::hasTerminated()`                                                            |
+| Method           | Parameter | Description                                                                                      |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `cancel`         |           | Cancel the scheduled timer                                                                       |
+| `execution_time` |           | Returns the timer's scheduled execution time as ZonedDateTime, or nil if the timer was cancelled |
+| `reschedule`     | duration  | Optional [duration](#Duration) if unspecified original duration supplied to after method is used |
+| `active?`        |           | An alias for `Timer::isActive()`                                                                 |
+| `running?`       |           | An alias for `Timer::isRunning()`                                                                |
+| `terminated?`    |           | An alias for `Timer::hasTerminated()`                                                            |
 
 ```ruby
 after 5.seconds do


### PR DESCRIPTION
I've recently submitted a PR to openhab-core to add Timer::getExecutionTime(). It's currently available in openhab 3.1 (snapshot).