### PR TITLE
feat: add Duration.to_s

### DIFF
--- a/lib/openhab/core/duration.rb
+++ b/lib/openhab/core/duration.rb
@@ -64,6 +64,15 @@ module OpenHAB
           @amount * 1000 * 60 * 60
         end
       end
+
+      #
+      # Return a string representation of the duration
+      #
+      # @return [String] Duration in string
+      #
+      def to_s
+        "#{@amount} #{(@amount == 1) ? @temporal_unit.to_s.downcase.delete_suffix('s') : @temporal_unit.to_s.downcase}"
+      end
     end
   end
 end


### PR DESCRIPTION
This would make logging the duration a bit nicer.

I was creating a way to define all my motion triggers and what they would do, including a configurable trigger duration for each case. I'd like to log the duration for it and haven't found an easy way to show the duration.

Case in point:
```ruby
        logger.info("Scheduling a timer for #{action_item.name} in #{config[:duration]}")
```
where config[:duration] is the Duration object e.g. `2.minutes`

