### PR TITLE
fix: items['nonexistent'] now returns nil, add items.include?

### DIFF
--- a/docs/usage/items.md
+++ b/docs/usage/items.md
@@ -15,6 +15,7 @@ All items can be accessed as an enumerable the `items` method.
 | Method             | Description                                                                    |
 | ------------------ | ------------------------------------------------------------------------------ |
 | []                 | Get a specific item by name, this syntax can be used to dynamically load items |
+| include?           | Check to see if an item with the given name exists                             |
 | enumerable methods | All methods [here](https://ruby-doc.org/core-2.5.0/Enumerable.html)            |
 
 ## Examples
@@ -29,6 +30,8 @@ Switch SwitchTest "Test Switch"
 ```ruby
 logger.info("Item Count: #{items.count}")  # Item Count: 2
 logger.info("Items: #{items.sort_by(&:label).map(&:label).join(', ')}")  #Items: Test Dimmer, Test Switch' 
+logger.info("DimmerTest exists? #{items.include? 'DimmerTest'}") # DimmerTest exists? true
+logger.info("StringTest exists? #{items.include? 'StringTest'}") # StringTest exists? false
 ```
 
 ```ruby

--- a/docs/usage/items.md
+++ b/docs/usage/items.md
@@ -41,6 +41,15 @@ rule 'Use dynamic item lookup to increase related dimmer brightness when switch 
 end
 ```
 
+```ruby
+rule 'search for a suitable item' do
+  on_start
+  triggered do
+    (items['DimmerTest'] || items['SwitchTest'])&.on # Send ON to DimmerTest if it exists, otherwise send it to SwitchTest
+  end
+end
+```
+
 ## All Items
 Item types have methods added to them to make it flow naturally within the a ruby context.  All methods of the OpenHAB item are available plus the additional methods described below.
 

--- a/features/items.feature
+++ b/features/items.feature
@@ -162,3 +162,13 @@ Feature:  Rule languages supports groups
       """
     When I deploy the rules file
     Then It should log "SwitchTest Received Update" within 5 seconds
+
+  Scenario: Check for item existence
+    Given code in a rules file
+      """
+      logger.info("DimmerTest include? #{items.include? 'DimmerTest'}")
+      logger.info("SimmerTest include? #{items.include? 'SimmerTest'}")
+      """
+    When I deploy the rules file
+    Then It should log 'DimmerTest include? true' within 5 seconds
+    And It should log 'SimmerTest include? false' within 5 seconds

--- a/features/items.feature
+++ b/features/items.feature
@@ -168,7 +168,9 @@ Feature:  Rule languages supports groups
       """
       logger.info("DimmerTest include? #{items.include? 'DimmerTest'}")
       logger.info("SimmerTest include? #{items.include? 'SimmerTest'}")
+      logger.info("SimmerTest item nil? #{items['SimmerTest'].nil?}")
       """
     When I deploy the rules file
     Then It should log 'DimmerTest include? true' within 5 seconds
     And It should log 'SimmerTest include? false' within 5 seconds
+    And It should log 'SimmerTest item nil? true' within 5 seconds

--- a/lib/openhab/core/dsl/items/items.rb
+++ b/lib/openhab/core/dsl/items/items.rb
@@ -22,6 +22,8 @@ module OpenHAB
             item = $ir.getItem(name)
             # rubocop: enable Style/GlobalVars
             (item.is_a? GroupItem) ? nil : item
+          rescue Java::OrgOpenhabCoreItems::ItemNotFoundException
+            nil
           end
 
           # Returns true if the given item name exists

--- a/lib/openhab/core/dsl/items/items.rb
+++ b/lib/openhab/core/dsl/items/items.rb
@@ -23,6 +23,14 @@ module OpenHAB
             # rubocop: enable Style/GlobalVars
             (item.is_a? GroupItem) ? nil : item
           end
+
+          # Returns true if the given item name exists
+          # @param name [String] Item name to check
+          # @return [Boolean] true if the item exists, false otherwise
+          def include?(name)
+            !$ir.getItems(name).empty?
+          end
+          alias key? include?
         end
 
         java_import org.openhab.core.items.GroupItem


### PR DESCRIPTION
Resolve #101 
Add items.include? to check for items existence
Make items['nonexistent'] to return nil. This will enable such shortcut:

```ruby
basename = 'LivingRoom'
power_item = items["#{basename}_Light_Dimmer"] ||  items["#{basename}_Light_Power"] ||  items["#{basename}_Light_Switch"]
power_item&.on
``` 