### PR TITLE
feat: DimmerItem becomes comparable

### DIFF
--- a/docs/usage/items/dimmer.md
+++ b/docs/usage/items/dimmer.md
@@ -14,17 +14,18 @@ DimmerItem  is aliased to **Dimmer** so you can compare compare item types using
 `item.is_a? Dimmer or grep(Dimmer)`
 
 
-| Method   | Parameters         | Description                                  | Example                                         |
-| -------- | ------------------ | -------------------------------------------- | ----------------------------------------------- |
-| truthy?  |                    | Item state not UNDEF, not NULL and is ON     | `puts "#{item.name} is truthy" if item.truthy?` |
-| on       |                    | Send command to turn item ON                 | `item.on`                                       |
-| off      |                    | Send command to turn item OFF                | `item.off`                                      |
-| on?      |                    | Returns true if item state == ON             | `puts "#{item.name} is on." if item.on?`        |
-| off?     |                    | Returns true if item state == OFF            | `puts "#{item.name} is off." if item.off?`      |
-| dim      | amount (default 1) | Dim the switch the specified amount          | `DimmerSwitch.dim`                              |
-| -        | amount             | Subtract the supplied amount from DimmerItem | `DimmerSwitch << DimmerSwitch - 5`              |
-| brighten | amount (default 1) | Brighten the switch the specified amount     | `DimmerSwitch.brighten`                         |
-| +        | amount             | Add the supplied amount from the DimmerItem  | `DimmerSwitch << DimmerSwitch + 5`              |
+| Method   | Parameters                             | Description                                    | Example                                         |
+| -------- | -------------------------------------- | ---------------------------------------------- | ----------------------------------------------- |
+| truthy?  |                                        | Item state not UNDEF, not NULL and is ON       | `puts "#{item.name} is truthy" if item.truthy?` |
+| on       |                                        | Send command to turn item ON                   | `item.on`                                       |
+| off      |                                        | Send command to turn item OFF                  | `item.off`                                      |
+| on?      |                                        | Returns true if item state == ON               | `puts "#{item.name} is on." if item.on?`        |
+| off?     |                                        | Returns true if item state == OFF              | `puts "#{item.name} is off." if item.off?`      |
+| dim      | amount (default 1)                     | Dim the switch the specified amount            | `DimmerSwitch.dim`                              |
+| -        | amount                                 | Subtract the supplied amount from DimmerItem   | `DimmerSwitch << DimmerSwitch - 5`              |
+| brighten | amount (default 1)                     | Brighten the switch the specified amount       | `DimmerSwitch.brighten`                         |
+| +        | amount                                 | Add the supplied amount from the DimmerItem    | `DimmerSwitch << DimmerSwitch + 5`              |
+| <=>      | DimmerItem, NumberItem, Number, String | Compare the value of DimmerItem against others | `DimmerSwitch > 100`                            |
 
 
 ## Examples

--- a/features/dimmer_item.feature
+++ b/features/dimmer_item.feature
@@ -121,3 +121,18 @@ Feature:  Rule languages supports Dimmers
     When I deploy the rules file
     Then It should log "Dimmer One is less than 50%" within 5 seconds
     And It should log "Dimmer Two is greater than 50%" within 5 seconds
+
+  Scenario: Dimmer can be compared against a number
+    Given code in a rules file
+      """
+      logger.info("DimmerOne #{DimmerOne}  DimmerTwo #{DimmerTwo}")
+      logger.info("DimmerOne == 50? #{DimmerOne == 50}")
+      logger.info("DimmerOne == DimmerTwo? #{DimmerOne == DimmerTwo}")
+      logger.info("DimmerOne > 50? #{DimmerOne > 50}")
+      logger.info("DimmerOne < 60? #{DimmerOne < 60}")
+      """
+    When I deploy the rules file
+    Then It should log "DimmerOne > 50? false" within 5 seconds
+    And It should log "DimmerOne == 50? true" within 5 seconds
+    And It should log "DimmerOne < 60? true" within 5 seconds
+    And It should log "DimmerOne == DimmerTwo? true" within 5 seconds

--- a/lib/openhab/core/dsl/monkey_patch/items/dimmer_item.rb
+++ b/lib/openhab/core/dsl/monkey_patch/items/dimmer_item.rb
@@ -14,6 +14,7 @@ Dimmer = DimmerItem
 #
 # rubocop:disable Style/ClassAndModuleChildren
 class Java::OrgOpenhabCoreLibraryItems::DimmerItem
+  include Comparable
   # rubocop:enable Style/ClassAndModuleChildren
   java_import org.openhab.core.library.types.DecimalType
   java_import org.openhab.core.library.types.IncreaseDecreaseType
@@ -86,6 +87,38 @@ class Java::OrgOpenhabCoreLibraryItems::DimmerItem
   end
 
   #
+  # Compare DimmerItem to supplied object
+  #
+  # @param [Object] other object to compare to
+  #
+  # @return [Integer] -1,0,1 or nil depending on value supplied, nil comparison to supplied object is not possible.
+  #
+  def <=>(other)
+    logger.trace("Comparing #{self} to #{other}")
+    case other
+    when DimmerItem, NumberItem
+      state <=> other.state
+    when DecimalType
+      state <=> other
+    else
+      to_i <=> other.to_i
+    end
+  end
+
+  #
+  # Compare DimmerItem to supplied object.
+  # The == operator needs to be overridden because the parent java object
+  # has .equals which overrides the <=> operator above
+  #
+  # @param [Object] other object to compare to
+  #
+  # @return [Integer] true if the two objects contain the same value, false otherwise
+  #
+  def ==(other)
+    (self <=> other).zero?
+  end
+
+  #
   # Check if dimmer has a state and state is not zero
   #
   # @return [Boolean] True if dimmer is not NULL or UNDEF and value is not 0
@@ -104,6 +137,15 @@ class Java::OrgOpenhabCoreLibraryItems::DimmerItem
   end
 
   alias to_int to_i
+
+  #
+  # Return the string representation of the dimmer item
+  #
+  # @return [String] String version of the dimmer value
+  #
+  def to_s
+    to_i.to_s
+  end
 
   #
   # Check if dimmer is on


### PR DESCRIPTION
Make DimmerItem comparable against a number, or another DimmerType, or a NumberType.
Implement to_s for DimmerItem to return the state / value.

I don't understand why I need to override the == operator in addition to <=> operator. The equality comparison does not call the spaceship <=> method for some reason.

