### PR TITLE
feat: Support Persistence features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 AllCops:
   TargetRubyVersion: 2.5
   NewCops: enable
+  SuggestExtensions: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openhab-scripting (2.14.1)
+    openhab-scripting (2.14.3)
       bundler (~> 2.2)
 
 GEM
@@ -247,4 +247,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.4
+   2.2.7

--- a/docs/usage/misc/persistence.md
+++ b/docs/usage/misc/persistence.md
@@ -1,0 +1,52 @@
+---
+layout: default
+title: Persistence
+nav_order: 2
+has_children: false
+parent: Misc
+grand_parent: Usage
+---
+
+# Persistence
+
+[Persistence](https://www.openhab.org/docs/configuration/persistence.html) functions can be accessed through the item object. The following methods related to persistence are available: 
+
+| Method            | Parameters                            | Example                                                         |
+| ----------------- | ------------------------------------- | --------------------------------------------------------------- |
+| `persist`         | service                               | `Item1.persist`                                                 |
+| `last_update`     | service                               | `Item1.last_update`                                             |
+| `previous_state`  | skip_equal: (default: false), service | `Item1.previous_state` `Item1.previous_state(skip_equal: true)` |
+| `average_since`   | timestamp, service                    | `Item1.average_since(-1.hours, :influxdb)`                      |
+| `changed_since`   | timestamp, service                    |                                                                 |
+| `delta_since`     | timestamp, service                    |                                                                 |
+| `deviation_since` | timestamp, service                    |                                                                 |
+| `evolution_rate`  | timestamp, service                    |                                                                 |
+| `historic_state`  | timestamp, service                    |                                                                 |
+| `maximum_since`   | timestamp, service                    |                                                                 |
+| `minimum_since`   | timestamp, service                    |                                                                 |
+| `sum_since`       | timestamp, service                    |                                                                 |
+| `updated_since`   | timestamp, service                    |                                                                 |
+| `variance_since`  | timestamp, service                    |                                                                 |
+
+* The `timestamp` parameter accepts a java ZonedDateTime or a [Duration](../duration/) object that specifies how far back in time.
+* The `service` optional parameter accepts the name of the persistence service to use, as a String or Symbol. When not specified, the system's default persistence service will be used.
+
+## Persistence Block
+
+A persistence block can group multiple persistence operations together under a single service. For example, instead of:
+
+```ruby
+Item1.persist(:influxdb)
+Item1.changed_since(1.hour, :influxdb)
+Item1.average_since(12.hours, :influxdb)
+```
+
+Using a persistence block:
+
+```ruby
+persistence(:influxdb) do
+  Item1.persist
+  Item1.changed_since(1.hour)
+  Item1.average_since(12.hours)
+end
+```

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -1,0 +1,64 @@
+Feature: persistence
+  Rule languages support Openhab Persistence
+
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
+    And feature 'openhab-persistence-rrd4j' installed
+    And items:
+      | type   | name    |
+      | Number | Number1 |
+      | Number | Number2 |
+
+  Scenario: Check that PersistenceExtensions is available
+    Given code in a rules file:
+      """
+      logger.info("Persistence is defined: #{defined? PersistenceExtensions}")
+      """
+    When I deploy the rule
+    Then It should log 'Persistence is defined: constant' within 5 seconds
+
+  Scenario: Make calls to various Persistence methods
+    Given code in a rules file:
+      """
+      java_import java.time.ZonedDateTime
+      @@last_update = nil
+
+      rule 'record updated time' do
+        updated Number1
+        triggered do |item|
+          @@last_update = ZonedDateTime.now
+          logger.info("#{item.name} = #{item.state} at: #{TimeOfDay.now}")
+        end
+      end
+
+      rule 'update' do
+        on_start
+        run do
+          Number1.update 10
+          sleep 1
+          persistence(:rrd4j) do
+            Number1.persist
+            logger.info("Last update: #{Number1.last_update}")
+            %w[
+            average_since
+            changed_since
+            delta_since
+            deviation_since
+            evolution_rate
+            historic_state
+            maximum_since
+            minimum_since
+            sum_since
+            updated_since
+            variance_since
+            ].each do |method|
+              logger.info("#{method}: #{Number1.send(method, 1.minute)}")
+              logger.info("#{method}: #{Number1.send(method, ZonedDateTime.now.minusMinutes(1))}")
+            end
+            logger.info("Persistence checks done")
+          end
+        end
+      end
+      """
+    When I deploy the rule
+    Then It should log 'Persistence checks done' within 5 seconds

--- a/lib/openhab/core/dsl.rb
+++ b/lib/openhab/core/dsl.rb
@@ -19,6 +19,7 @@ require 'core/dsl/gems'
 require 'core/dsl/units'
 require 'core/dsl/types/quantity'
 require 'core/dsl/states'
+require 'core/dsl/persistence'
 
 module OpenHAB
   #
@@ -30,6 +31,7 @@ module OpenHAB
     #
     module DSL
       # Extend the calling module/class with the DSL
+      # rubocop: disable Metrics/MethodLength
       def self.extended(base)
         base.send :include, OpenHAB::Core::DSL::Rule
         base.send :include, OpenHAB::Core::DSL::Items
@@ -40,8 +42,10 @@ module OpenHAB
         base.send :include, OpenHAB::Core::DSL::Timers
         base.send :include, OpenHAB::Core::DSL::States
         base.send :include, OpenHAB::Core::DSL::Tod
+        base.send :include, OpenHAB::Core::DSL::Persistence
         base.send :include, Things
       end
+      # rubocop: enable Metrics/MethodLength
     end
   end
 end

--- a/lib/openhab/core/dsl/monkey_patch/items/items.rb
+++ b/lib/openhab/core/dsl/monkey_patch/items/items.rb
@@ -6,6 +6,7 @@ require 'bigdecimal'
 
 # Monkey patch items
 require 'openhab/core/dsl/monkey_patch/items/metadata'
+require 'openhab/core/dsl/monkey_patch/items/persistence'
 require 'openhab/core/dsl/monkey_patch/items/contact_item'
 require 'openhab/core/dsl/monkey_patch/items/dimmer_item'
 require 'openhab/core/dsl/monkey_patch/items/switch_item'
@@ -127,4 +128,5 @@ class Java::OrgOpenhabCoreItems::GenericItem
   # rubocop:enable Style/ClassAndModuleChildren
   prepend OpenHAB::Core::DSL::MonkeyPatch::Items::ItemExtensions
   prepend OpenHAB::Core::DSL::MonkeyPatch::Items::Metadata
+  prepend OpenHAB::Core::DSL::MonkeyPatch::Items::Persistence
 end

--- a/lib/openhab/core/dsl/monkey_patch/items/persistence.rb
+++ b/lib/openhab/core/dsl/monkey_patch/items/persistence.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module Core
+    module DSL
+      module MonkeyPatch
+        module Items
+          #
+          # Persistence extension for Items
+          #
+          module Persistence
+            %w[persist last_update].each do |method|
+              define_method(method) do |service = nil|
+                service ||= persistence_service
+                PersistenceExtensions.public_send(method, self, service&.to_s)
+              end
+            end
+
+            #
+            # Return the previous state of the item
+            #
+            # @param skip_equal [Boolean] if true, skips equal state values and
+            #        searches the first state not equal the current state
+            # @param service [String] the name of the PersistenceService to use
+            #
+            # @return the previous state or nil if no previous state could be found,
+            #         or if the default persistence service is not configured or
+            #         does not refer to a valid service
+            #
+            def previous_state(service = nil, skip_equal: false)
+              service ||= persistence_service
+              PersistenceExtensions.previous_state(self, skip_equal, service&.to_s)
+            end
+
+            %w[
+              average_since
+              changed_since
+              delta_since
+              deviation_since
+              evolution_rate
+              historic_state
+              maximum_since
+              minimum_since
+              sum_since
+              updated_since
+              variance_since
+            ].each do |method|
+              define_method(method) do |timestamp, service = nil|
+                service ||= persistence_service
+                if timestamp.is_a? Java::JavaTimeTemporal::TemporalAmount
+                  timestamp = Java::JavaTime::ZonedDateTime.now.minus(timestamp)
+                end
+                PersistenceExtensions.public_send(method, self, timestamp, service&.to_s)
+              end
+            end
+
+            private
+
+            #
+            # Get the specified persistence service from the current thread local variable
+            #
+            # @return [Object] Persistence service name as String or Symbol, or nil if not set
+            #
+            def persistence_service
+              Thread.current.thread_variable_get(:persistence_service)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openhab/core/dsl/persistence.rb
+++ b/lib/openhab/core/dsl/persistence.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module Core
+    module DSL
+      #
+      # Provides support for interacting with OpenHAB Persistence service
+      #
+      module Persistence
+        #
+        # Sets a thread local variable to set the default persistence service
+        # for method calls inside the block
+        #
+        # @param [Object] Persistence service either as a String or a Symbol
+        # @yield [] Block executed in context of the supplied persistence service
+        #
+        #
+        def persistence(service)
+          Thread.current.thread_variable_set(:persistence_service, service)
+          yield
+        ensure
+          Thread.current.thread_variable_set(:persistence_service, nil)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolve #50 
Add Persistence methods to Items. It accepts a relative duration in addition to ZonedDateTime, e.g. 
```
Item1.average_since 12.hours #or
Item1.average_since ZonedDateTime.now.minusHours(12)
```

To specify the persistence service: (I dropped the idea of named parameter)
```
Item1.last_update 'influxdb'
Item1.sum_since 1.hour, :influxdb #it could accept a symbol
```

