### PR TITLE
feat(logging): append rule name to logging class if logging within ru…

### DIFF
--- a/features/logging.feature
+++ b/features/logging.feature
@@ -36,3 +36,16 @@ Feature:  logging
       """
     When I deploy the rules file named "log_test.rb"
     Then It should log 'jsr223.jruby.log_test' within 5 seconds
+
+  Scenario: Logging should include rule name inside a rule
+    Given a rule:
+      """
+      rule 'log test' do
+        on_start
+        run { logger.info('Log Test') }
+      end
+
+      """
+    When I deploy the rule
+    Then It should log 'jsr223.jruby.log_test' within 5 seconds
+

--- a/lib/openhab/core/dsl/rule/rule.rb
+++ b/lib/openhab/core/dsl/rule/rule.rb
@@ -113,6 +113,19 @@ module OpenHAB
           def my(&block)
             @caller.instance_eval(&block)
           end
+
+          #
+          # Create a logger where name includes rule name if name is set
+          #
+          # @return [Logging::Logger] Logger with name that appended with rule name if rule name is set
+          #
+          def logger
+            if name
+              Logging.logger(name.chomp.gsub(/\s+/, '_'))
+            else
+              super
+            end
+          end
         end
 
         #


### PR DESCRIPTION
@jimtng  can you take a look at this?  I wrote a test and stole some of our code.  However, this should log the rule name when run within the rule context.