### PR TITLE
docs(ui-rules): add blank lines to fix formatting

### DIFF
--- a/docs/usage/ui-rules.md
+++ b/docs/usage/ui-rules.md
@@ -35,6 +35,7 @@ Trigger defined as:
 - When: a member of an item group recieves a command
 - Group: Reset_5Seconds
 - Command: ON
+
 ```ruby
 require 'openhab'
 
@@ -50,6 +51,7 @@ Trigger defined as:
 - When: the state of a member of an item group is updated
 - Group: MotionSensors
 - State: ON
+
 ```ruby
 require 'openhab'
 


### PR DESCRIPTION
There was some formatting issues due to missing blank lines between list and code section.

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>