### PR TITLE
feat: add dig-method to top level metadata

### DIFF
--- a/docs/usage/misc/metadata.md
+++ b/docs/usage/misc/metadata.md
@@ -13,13 +13,14 @@ Item metadata can be accessed through `Item.meta` using the hash syntax. The `It
 
 In addition to the Enumerable methods, the following methods are available for `Item.meta`:
 
-| Method     | Parameters               | Description                                | Example                          |
-| ---------- | ------------------------ | ------------------------------------------ | -------------------------------- |
-| clear      |                          | Deletes all metadata namespaces            | `Item1.meta.clear`               |
-| delete     | namespace                | Delete the given namespace                 | `Item1.meta.delete 'namespace1'` |
-| each       | namespace, value, config | Loops through all the item's namespaces    |                                  |
-| merge!     | **other                  | Merge a hash or other item's metadata      |                                  |
-| namespace? | namespace                | Returns true if the given namespace exists |                                  |
+| Method     | Parameters               | Description                                           | Example                                     |
+| ---------- | ------------------------ | ----------------------------------------------------- | ------------------------------------------- |
+| clear      |                          | Deletes all metadata namespaces                       | `Item1.meta.clear`                          |
+| delete     | namespace                | Delete the given namespace                            | `Item1.meta.delete 'namespace1'`            |
+| dig        | key, *keys               | Dig through the namespace to find the specified value | `Item1.meta.dig('namespace1', 'foo', 'bar') |
+| each       | namespace, value, config | Loops through all the item's namespaces               |                                             |
+| merge!     | **other                  | Merge a hash or other item's metadata                 |                                             |
+| namespace? | namespace                | Returns true if the given namespace exists            |                                             |
 
 Metadata configuration is a hash and can be accessed using a subscript of `Item.meta['namespace']`. For example, the following Item metadata
 
@@ -60,6 +61,11 @@ Item1.meta['namespace1'].value
 
 # Access namespace1's configuration
 Item1.meta['namespace1']['config1']
+
+# Safely search for the specified value - no errors are raised, only nil returned if a key
+# in the chain doesn't exist
+Item1.meta.dig('namespace1', 'config1') #=> 'foo'
+Item1.meta.dig('namespace2', 'config1') #=> nil
 
 # Set item's metadata value, preserving its config
 # Item1's metadata before: { namespace1="value" [ config1="foo", config2="bar" ] }

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -274,5 +274,29 @@ Feature:  metadata
     Then It should log 'TestSwitch ts1: value=foo config={"bar"=>"baz"}' within 5 seconds
     Then It should log 'TestSwitch ts2: value=boo config={"moo"=>"goo"}' within 5 seconds
 
+  Scenario: Dig works on top level metadata namespace
+    Given metadata added to "TestSwitch" in namespace "test":
+      """
+      {
+      "value": "foo",
+      "config": {
+      "bar": 'baz',
+      "qux": 'quux'
+      }
+      }
+      """
+    And code in a rules file:
+      """
+      logger.info("TestSwitch value for dig('test') is: #{TestSwitch.meta.dig('test')}")
+      logger.info("TestSwitch value for dig('test', 'qux') is: #{TestSwitch.meta.dig('test', 'qux')}")
+      logger.info("TestSwitch value for dig('nonexistent', 'qux') is nil?: #{TestSwitch.meta.dig('nonexistent', 'qux').nil?}")
+      logger.info("TestSwitch value for dig('test', 'nonexistent') is nil?: #{TestSwitch.meta.dig('test', 'nonexistent').nil?}")
+      """
+    When I deploy the rules file
+    Then It should log "TestSwitch value for dig('test') is: foo" within 5 seconds
+    And It should log "TestSwitch value for dig('test', 'qux') is: quux" within 5 seconds
+    And It should log "TestSwitch value for dig('nonexistent', 'qux') is nil?: true" within 5 seconds
+    And It should log "TestSwitch value for dig('test', 'nonexistent') is nil?: true" within 5 seconds
+
 
 

--- a/lib/openhab/dsl/monkey_patch/items/metadata.rb
+++ b/lib/openhab/dsl/monkey_patch/items/metadata.rb
@@ -135,6 +135,18 @@ module OpenHAB
             end
 
             #
+            # Implements Hash#dig-like functionaity to metadata
+            #
+            # @param [String] key The first key
+            # @param [Array<String, Symbol>] keys More keys to dig deeper
+            #
+            # @return [OpenHAB::DSL::MonkeyPatch::Items::MetadataItem], or nil if the namespace doesn't exist
+            #
+            def dig(key, *keys)
+              keys.empty? ? self[key]&.value : self[key]&.dig(*keys)
+            end
+
+            #
             # Enumerates through all the namespaces
             #
             def each


### PR DESCRIPTION
Added a dig method to the top level metadata namespace, so you can include all levels in a single query and not worry about if one level is missing.

Fixes #158 

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>