### PR TITLE
docs: fix typo on datetime doc

### DIFF
--- a/docs/usage/items/datetime.md
+++ b/docs/usage/items/datetime.md
@@ -9,7 +9,7 @@ grand_parent: Usage
 
 # DateTime Item
 
-DateTime items are extended with a lot of methods that make working with them easy. Most ot the methods
+DateTime items are extended with a lot of methods that make working with them easy. Most of the methods
 defined by the [ruby Time class](https://ruby-doc.org/core-2.5.8/Time.html) are available, and some of 
 them are extended or adapted with OpenHAB specific functionality.
 


### PR DESCRIPTION
I was just reading the announcement and clicked on the doc. Noticed a one letter typo.