### PR TITLE
fix(changed_duration): cancel 'changed for' timer correctly

### DIFF
--- a/features/changed_duration.feature
+++ b/features/changed_duration.feature
@@ -44,10 +44,26 @@ Feature: changed_duration
     When item "Alarm_Mode" state is changed to "14"
     Then If I wait 5 seconds
     And item "Alarm_Mode" state is changed to "10"
-    And It should not log 'Alarm Mode Updated' within 20 seconds
+    And It should not log 'Alarm Mode Updated to 14' within 20 seconds
     But If I wait 5 seconds
     Then It should log 'Alarm Mode Updated to 10' within 10 seconds
 
+  Scenario: Changed item has to and duration specified and is modified during that duration
+    Given items:
+      | type   | name       | label      |
+      | Number | Alarm_Mode | Alarm Mode |
+    And a deployed rule:
+      """
+      rule "Execute rule when item is changed and is modified during specified duration" do
+        changed Alarm_Mode, to: 14, for: 20.seconds
+        triggered { |item| logger.info("Alarm Mode Updated to #{item}")}
+      end
+      """
+    When item "Alarm_Mode" state is changed to "14"
+    Then If I wait 5 seconds
+    And item "Alarm_Mode" state is changed to "10"
+    Then It should not log 'Alarm Mode Updated to 14' within 20 seconds
+    And It should not log 'Alarm Mode Updated to 10' within 20 seconds
 
   Scenario Outline: Changed group items supports duration and/or to and/or from.
     Given group "Modes"

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -145,16 +145,14 @@ module OpenHAB
         #
         #
         def process_trigger_delay(trigger_delay, mod, inputs)
-          if check_trigger_guards(trigger_delay, inputs)
+          if trigger_delay.timer_active?
+            process_active_timer(inputs, mod, trigger_delay)
+          elsif check_trigger_guards(trigger_delay, inputs)
             logger.trace("Trigger Guards Matched for #{trigger_delay}, delaying rule execution")
             # Add timer and attach timer to delay object, and also state being tracked to so timer can be cancelled if
             #   state changes
             # Also another timer should not be created if changed to same value again but instead rescheduled
-            if trigger_delay.timer_active?
-              process_active_timer(inputs, mod, trigger_delay)
-            else
-              create_trigger_delay_timer(inputs, mod, trigger_delay)
-            end
+            create_trigger_delay_timer(inputs, mod, trigger_delay)
           else
             logger.trace("Trigger Guards did not match for #{trigger_delay}, ignoring trigger.")
           end


### PR DESCRIPTION
Fixes #163 

Just had to restructure the logic in the `process_trigger_delay` so it always processes the trigger if a timer for that trigger is active.
Added test to verify.

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>