### PR TITLE
fix(items): to_s did not include UNDEF and NULL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openhab-scripting (2.19.1)
+    openhab-scripting (2.19.2)
       bundler (~> 2.2)
 
 GEM

--- a/features/items.feature
+++ b/features/items.feature
@@ -128,6 +128,8 @@ Feature:  items
       | Dimmer  | 50             |
       | Contact | OPEN           |
       | Number  | 90.6           |
+      | Number  | NULL           |
+      | Number  | UNDEF          |
 
 
   Scenario: Items in array work with array methods

--- a/lib/openhab/dsl/monkey_patch/items/items.rb
+++ b/lib/openhab/dsl/monkey_patch/items/items.rb
@@ -101,10 +101,10 @@ module OpenHAB
           #
           # Get the string representation of the state of the item
           #
-          # @return [String] State of the item as a string if not UNDEF or NULL, nil otherwise
+          # @return [String] State of the item as a string
           #
           def to_s
-            state&.to_s
+            method(:state).super_method.call.to_s # call the super state to include UNDEF/NULL
           end
 
           #


### PR DESCRIPTION
When the Item's state is NULL or UNDEF, `"#{Item}"` will expand to the object's address instead of saying NULL or UNDEF. This PR will fix this.
Fix #173 