### PR TITLE
fix(rule): otherwise blocks are always executed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openhab-scripting (2.19.1)
+    openhab-scripting (2.19.2)
       bundler (~> 2.2)
 
 GEM

--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -63,7 +63,7 @@ Feature: rule_language
     When I deploy the rules file
     Then It should log 'Found Dimmer Switch' within 5 seconds
 
-  Scenario: Rule supports executing different block if guards are not satisfied
+  Scenario Outline: Rule supports executing different block if guards are not satisfied
     Given items:
       | type   | name       | state |
       | Switch | TestSwitch | ON    |
@@ -73,11 +73,15 @@ Feature: rule_language
         on_start
         run { TestSwitch << ON }
         otherwise { TestSwitch << OFF }
-        only_if { false }
+        only_if { <condition> }
       end
       """
     When I deploy the rule
-    Then "TestSwitch" should be in state "OFF" within 5 seconds
+    Then "TestSwitch" should be in state "<outcome>" within 5 seconds
+    Examples: Check different conditions
+      | condition | outcome |
+      | true      | ON      |
+      | false     | OFF     |
 
 
   Scenario: Rule logs a warning and isn't created if it contains no execution blocks

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -70,7 +70,7 @@ module OpenHAB
         def create_queue(inputs)
           case check_guards(event: inputs&.dig('event'))
           when true
-            @run_queue.dup
+            @run_queue.dup.grep_v(RuleConfig::Otherwise)
           when false
             @run_queue.dup.grep(RuleConfig::Otherwise)
           end


### PR DESCRIPTION
I noticed that `otherwise` blocks are always executed regardless of guard conditions. This PR fixes that issue.
