### PR TITLE
fix(changed_duration): stringitem from/to comparison didn't work

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openhab-scripting (2.19.2)
+    openhab-scripting (2.20.1)
       bundler (~> 2.2)
 
 GEM

--- a/features/changed_duration.feature
+++ b/features/changed_duration.feature
@@ -161,3 +161,20 @@ Feature: changed_duration
       | condition | should     |
       | false     | should not |
       | true      | should     |
+
+  Scenario: Changed duration with StringItem
+    Given items:
+      | type   | name       | label      | state |
+      | String | String_One | String One | ONE   |
+    And a rule:
+      """
+    rule 'Changed String' do
+      changed String_One, to: 'TWO', for: 2.seconds
+      triggered do |item|
+        logger.info("Changed rule: #{item.name} changed")
+      end
+    end
+      """
+    When I deploy the rule
+    And item "String_One" state is changed to "TWO"
+    Then It should log "Changed rule: String_One changed" within 5 seconds

--- a/lib/openhab/dsl/monkey_patch/ruby/string.rb
+++ b/lib/openhab/dsl/monkey_patch/ruby/string.rb
@@ -21,7 +21,7 @@ module OpenHAB
           #
           def ==(other)
             case other
-            when OpenHAB::DSL::Types::Quantity, QuantityType
+            when OpenHAB::DSL::Types::Quantity, QuantityType, Java::OrgOpenhabCoreLibraryTypes::StringType
               other == self
             else
               super

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -122,7 +122,7 @@ module OpenHAB
         # @return [Boolean] true if no from state is defined or defined state equals supplied state
         #
         def check_from(trigger_delay, state)
-          trigger_delay.from.nil? || trigger_delay.from == state
+          trigger_delay.from.nil? || state == trigger_delay.from
         end
 
         #
@@ -134,7 +134,7 @@ module OpenHAB
         # @return [Boolean] true if no to state is defined or defined state equals supplied state
         #
         def check_to(trigger_delay, state)
-          trigger_delay.to.nil? || trigger_delay.to == state
+          trigger_delay.to.nil? || state == trigger_delay.to
         end
 
         #


### PR DESCRIPTION
The from: and to: comparison for changed_duration on StringItem didn't work, because Ruby String didn't know how to compare against Openhab StringType. This PR should fix it.