### PR TITLE
feat(persistence): automatically convert to quantity for dimensioned items

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openhab-scripting (2.19.2)
+    openhab-scripting (2.20.1)
       bundler (~> 2.2)
 
 GEM

--- a/docs/usage/misc/persistence.md
+++ b/docs/usage/misc/persistence.md
@@ -30,6 +30,23 @@ grand_parent: Usage
 
 * The `timestamp` parameter accepts a java ZonedDateTime or a [Duration](../duration/) object that specifies how far back in time.
 * The `service` optional parameter accepts the name of the persistence service to use, as a String or Symbol. When not specified, the system's default persistence service will be used.
+* The return value of the persistence methods is a Quantity when the corresponding item is a dimensioned NumberItem
+
+### Examples:
+
+Given the following items are configured to persist on every change:
+```
+Number        UV_Index
+Number:Power  Power_Usage "Power Usage [%.2f W]"
+```
+
+```ruby
+# UV_Index average will return a DecimalType
+logger.info("UV_Index Average: #{UV_Index.average_since(12.hours)}") 
+# Power_Usage has a Unit of Measurement, so 
+# Power_Usage.average_since will return a Quantity with the same unit
+logger.info("Power_Usage Average: #{Power_Usage.average_since(12.hours)}") 
+```
 
 ## Persistence Block
 

--- a/lib/openhab/dsl/monkey_patch/items/persistence.rb
+++ b/lib/openhab/dsl/monkey_patch/items/persistence.rb
@@ -49,7 +49,12 @@ module OpenHAB
               if timestamp.is_a? Java::JavaTimeTemporal::TemporalAmount
                 timestamp = Java::JavaTime::ZonedDateTime.now.minus(timestamp)
               end
-              PersistenceExtensions.public_send(method, self, timestamp, service&.to_s)
+              result = PersistenceExtensions.public_send(method, self, timestamp, service&.to_s)
+              if result.is_a?(Java::OrgOpenhabCoreLibraryTypes::DecimalType) && respond_to?(:unit) && unit
+                Quantity.new(Java::OrgOpenhabCoreLibraryTypes::QuantityType.new(result.to_big_decimal, unit))
+              else
+                result
+              end
             end
           end
 


### PR DESCRIPTION
This PR makes return value of the persistence functions converted to Quantity with the same unit as the attached NumberItem

Somewhat related to #153 which will apply more generically to any DecimalType data, whereas this PR applies specifically to persistence without having to specify the unit.