### PR TITLE
refactor: automatically infer accepted types from OH item

### DIFF
--- a/lib/openhab/dsl/items/datetime_item.rb
+++ b/lib/openhab/dsl/items/datetime_item.rb
@@ -17,10 +17,12 @@ module OpenHAB
       class DateTimeItem
         extend Forwardable
         extend OpenHAB::DSL::Items::ItemDelegate
-
+        extend OpenHAB::DSL::Items::ItemCommand
         include Comparable
 
         def_item_delegator :@datetime_item
+
+        item_type Java::OrgOpenhabCoreLibraryItems::DateTimeItem
 
         #
         # Create a new DateTimeItem

--- a/lib/openhab/dsl/items/item_command.rb
+++ b/lib/openhab/dsl/items/item_command.rb
@@ -51,6 +51,21 @@ module OpenHAB
           end
           # rubocop:enable Style/HashEachMethods
         end
+
+        #
+        # Extract the accepted state and command types from the specified OpenHAB
+        # Item class and pass them to item_state/item_command
+        #
+        # @param [Java::JavaLang::Class] item_class a Class that implements Java::OrgOpenhabCoreItems::Item
+        #
+        def item_type(item_class)
+          item_class.field_reader(:ACCEPTED_DATA_TYPES)
+          item_class.field_reader(:ACCEPTED_COMMAND_TYPES)
+          item_class.ACCEPTED_DATA_TYPES.select(&:is_enum).grep_v(UnDefType).each { |type| item_state(type.ruby_class) }
+          item_class.ACCEPTED_COMMAND_TYPES.select(&:is_enum).grep_v(UnDefType).each do |type|
+            item_command(type.ruby_class)
+          end
+        end
       end
     end
   end

--- a/lib/openhab/dsl/items/number_item.rb
+++ b/lib/openhab/dsl/items/number_item.rb
@@ -17,6 +17,7 @@ module OpenHAB
       # way of breaking it up into multiple classes
       class NumberItem < Numeric
         extend OpenHAB::DSL::Items::ItemDelegate
+        extend OpenHAB::DSL::Items::ItemCommand
 
         def_item_delegator :@number_item
 
@@ -24,6 +25,8 @@ module OpenHAB
         java_import org.openhab.core.library.types.QuantityType
         java_import 'tec.uom.se.format.SimpleUnitFormat'
         java_import 'tec.uom.se.AbstractUnit'
+
+        item_type Java::OrgOpenhabCoreLibraryItems::NumberItem
 
         #
         # Create a new NumberItem

--- a/lib/openhab/dsl/items/rollershutter_item.rb
+++ b/lib/openhab/dsl/items/rollershutter_item.rb
@@ -19,13 +19,7 @@ module OpenHAB
 
         def_item_delegator :@rollershutter_item
 
-        java_import Java::OrgOpenhabCoreLibraryTypes::PercentType
-        java_import Java::OrgOpenhabCoreLibraryTypes::UpDownType
-        java_import Java::OrgOpenhabCoreLibraryTypes::StopMoveType
-
-        item_command Java::OrgOpenhabCoreLibraryTypes::StopMoveType
-        item_command Java::OrgOpenhabCoreLibraryTypes::UpDownType
-        item_state   Java::OrgOpenhabCoreLibraryTypes::UpDownType
+        item_type Java::OrgOpenhabCoreLibraryItems::RollershutterItem
 
         #
         # Creates a new RollershutterItem

--- a/lib/openhab/dsl/items/string_item.rb
+++ b/lib/openhab/dsl/items/string_item.rb
@@ -13,7 +13,7 @@ module OpenHAB
       #
       class StringItem
         extend Forwardable
-
+        extend OpenHAB::DSL::Items::ItemCommand
         include Comparable
         extend OpenHAB::DSL::Items::ItemDelegate
 
@@ -22,6 +22,8 @@ module OpenHAB
         private_constant :BLANK_RE
 
         def_item_delegator :@string_item
+
+        item_type Java::OrgOpenhabCoreLibraryItems::StringItem
 
         #
         # Create a new StringItem

--- a/lib/openhab/dsl/monkey_patch/items/contact_item.rb
+++ b/lib/openhab/dsl/monkey_patch/items/contact_item.rb
@@ -25,7 +25,7 @@ module OpenHAB
 
           java_import Java::OrgOpenhabCoreLibraryTypes::OpenClosedType
 
-          item_state Java::OrgOpenhabCoreLibraryTypes::OpenClosedType
+          item_type Java::OrgOpenhabCoreLibraryItems::ContactItem
 
           #
           # Compares contacts to OpenClosedTypes

--- a/lib/openhab/dsl/monkey_patch/items/dimmer_item.rb
+++ b/lib/openhab/dsl/monkey_patch/items/dimmer_item.rb
@@ -30,8 +30,7 @@ module OpenHAB
           extend Forwardable
           extend OpenHAB::DSL::Items::ItemCommand
 
-          item_state Java::OrgOpenhabCoreLibraryTypes::OnOffType
-          item_command Java::OrgOpenhabCoreLibraryTypes::IncreaseDecreaseType
+          item_type Java::OrgOpenhabCoreLibraryItems::DimmerItem
 
           def_delegator :state, :to_s
 

--- a/lib/openhab/dsl/monkey_patch/items/switch_item.rb
+++ b/lib/openhab/dsl/monkey_patch/items/switch_item.rb
@@ -23,8 +23,7 @@ module OpenHAB
 
           java_import Java::OrgOpenhabCoreLibraryTypes::OnOffType
 
-          item_command Java::OrgOpenhabCoreLibraryTypes::OnOffType
-          item_state Java::OrgOpenhabCoreLibraryTypes::OnOffType
+          item_type Java::OrgOpenhabCoreLibraryItems::SwitchItem
 
           alias truthy? on?
 


### PR DESCRIPTION
Added the ability to automatically detect accepted states/command from the OH item. Or is that too much?

Had to create a dummy item, because the `getAccepted*Types`-methods are instance methods. Or is there a way to read private static fields from jruby?

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>