### PR TITLE
feat: add stack trace to errors

### DIFF
--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -27,6 +27,8 @@ module OpenHAB
         config.guard = Guard::Guard.new(only_if: config.only_if, not_if: config.not_if)
         logger.trace { config.inspect }
         process_rule_config(config)
+      rescue StandardError => e
+        re_raise_with_backtrace(e)
       end
 
       #
@@ -43,6 +45,16 @@ module OpenHAB
       end
 
       private
+
+      #
+      # Re-raises a rescued error to OpenHAB with added rule name and stack trace
+      #
+      # @param [Exception] error A rescued error
+      #
+      def re_raise_with_backtrace(error)
+        error = logger.clean_backtrace(error)
+        raise error, "#{error.message}\nIn rule: #{@rule_name}\n#{error.backtrace.join("\n")}"
+      end
 
       #
       # Process a rule based on the supplied configuration


### PR DESCRIPTION
Added some rescue clauses to catch errors in scripts and log them along with stack traces. If the error is in the parsing of the file the error is re-raised to the ScriptEngineManager, but with the stack trace added. If the error is raised when the rule is executed it is handled internally and logged together with the stack trace. The errors are rescued for a single execution block, which allows other blocks in the same rule to run as usual.

In both cases the stack frames pertaining to internal classes/methods (script-library and jruby) are removed, so only the lines relevant to the end user are shown.

WDYT?

Fixes #17

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>