### PR TITLE
fix(metadata): convert value to string before assignment

### DIFF
--- a/docs/usage/misc/metadata.md
+++ b/docs/usage/misc/metadata.md
@@ -49,6 +49,7 @@ With the following item definition:
 
 ```
 Switch Item1 { namespace1="value" [ config1="foo", config2="bar" ] }
+String StringItem1
 ```
 
 ```ruby
@@ -134,4 +135,14 @@ Item1.meta.clear
 
 # Does this item have any metadata?
 Item1.meta.any?
+
+# Store another item's state
+StringItem1.update 'TEST'
+Item1.meta['other_state'] = StringItem1
+
+# Store event's state
+rule 'save event state' do
+  changed StringItem1
+  run { |event| Item1.meta['last_event'] = event.last }
+end
 ```

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -298,5 +298,28 @@ Feature:  metadata
     And It should log "TestSwitch value for dig('nonexistent', 'qux') is nil?: true" within 5 seconds
     And It should log "TestSwitch value for dig('test', 'nonexistent') is nil?: true" within 5 seconds
 
+  Scenario Outline: Item assigned to metadata value
+    Given items:
+      | type   | name   | state   |
+      | <type> | <item> | <state> |
+    And code in a rules file:
+      """
+      TestSwitch.meta['test'] = <item>
+      logger.info("TestSwitch metadata value for 'test' is: #{TestSwitch.meta['test'].value}")
+      """
+    When I deploy the rules file
+    Then It should log "TestSwitch metadata value for 'test' is: <state>" within 5 seconds
+    Examples: using different item types
+      | type               | item     | state  |
+      # | Color | Col_Item | 10,20,30 | # TODO: COLOR Item is not yet properly implemented to return its values
+      | Contact            | Ctc_Item | CLOSED |
+      | Dimmer             | Dim_Item | 60     |
+      | Number             | Num_Item | 1.12   |
+      | Number:Temperature | Tmp_Item | 12 °C  |
+      | Rollershutter      | Rol_Item | 33     |
+      | String             | Str_Item | foo    |
+      | Switch             | Swc_Item | ON     |
+
+
 
 

--- a/lib/openhab/dsl/monkey_patch/items/metadata.rb
+++ b/lib/openhab/dsl/monkey_patch/items/metadata.rb
@@ -29,7 +29,7 @@ module OpenHAB
             def_delegator :@metadata, :value
 
             def initialize(metadata: nil, key: nil, value: nil, config: nil)
-              @metadata = metadata || Metadata.new(key || MetadataKey.new('', ''), value, config)
+              @metadata = metadata || Metadata.new(key || MetadataKey.new('', ''), value&.to_s, config)
               super(@metadata&.configuration)
             end
 
@@ -60,9 +60,7 @@ module OpenHAB
             # @return [Java::Org::openhab::core::items::Metadata] the old metadata
             #
             def value=(value)
-              raise ArgumentError, 'Value must be a string' unless value.is_a? String
-
-              metadata = Metadata.new(@metadata&.uID, value, @metadata&.configuration)
+              metadata = Metadata.new(@metadata&.uID, value&.to_s, @metadata&.configuration)
               NamespaceAccessor.registry.update(metadata) if @metadata&.uID
             end
 
@@ -125,7 +123,7 @@ module OpenHAB
               meta_value, configuration = update_from_value(value)
 
               key = MetadataKey.new(namespace, @item_name)
-              metadata = Metadata.new(key, meta_value, configuration)
+              metadata = Metadata.new(key, meta_value&.to_s, configuration)
               # registry.get can be omitted, but registry.update will log a warning for nonexistent metadata
               if NamespaceAccessor.registry.get(key)
                 NamespaceAccessor.registry.update(metadata)


### PR DESCRIPTION
Instead of 
```ruby
Item1.meta['ns'] = event.last.to_s # This could be a StringType, or any other type / object
```

This PR calls the object's to_s so we can do:
```ruby
Item1.meta['ns'] = event.last
```