### PR TITLE
refactor(event.item): monkey patch ItemEvent to provide decorated event.item

### DIFF
--- a/features/run.feature
+++ b/features/run.feature
@@ -72,18 +72,49 @@ Feature:  run
     Then It should log 'from OFF' within 5 seconds
     Then It should log 'to ON' within 5 seconds
 
-  Scenario: Verify decoration of event.item
+  Scenario Outline: Verify decoration of event.item
     Given items:
       | type   | name    | state |
       | Number | Number1 | 1     |
     And code in a rules file
       """
-      rule 'Run event item' do
-        changed Number1
-        run { |event| logger.info("event.item class is #{event.item.class}") }
+      rule 'Run and triggered event item' do
+        <trigger> Number1
+        run { |event| logger.info("run event.item class is #{event.item.class}") }
+        triggered { |item| logger.info("triggered item class is #{item.class}") }
       end
       """
     When I deploy the rules file
     And item "Number1" state is changed to "2"
-    Then It should log "event.item class is OpenHAB::DSL::Items::NumberItem" within 5 seconds
+    Then It should log "run event.item class is OpenHAB::DSL::Items::NumberItem" within 5 seconds
+    And It should log "triggered item class is OpenHAB::DSL::Items::NumberItem" within 5 seconds
+    Examples: Test different triggers
+      | trigger          |
+      | updated          |
+      | changed          |
+      | received_command |
 
+  Scenario Outline: Verify decoration of event.item on a group
+    Given groups:
+      | type   | name     | function | params |
+      | Switch | Switches | OR       | ON,OFF |
+    And items:
+      | type   | name       | group    | state |
+      | Switch | Switch_One | Switches | OFF   |
+    And code in a rules file
+      """
+    rule 'Run and triggered event item on a group' do
+      <trigger> Switches
+      run { |event| logger.info("run event.item class is #{event.item.class}") }
+      triggered { |item| logger.info("triggered item class is #{item.class}") }
+    end
+      """
+    When I deploy the rules file
+    And item "Switches" state is changed to "ON"
+    Then It should log "run event.item class is OpenHAB::DSL::Groups::Group" within 5 seconds
+    And It should log "triggered item class is OpenHAB::DSL::Groups::Group" within 5 seconds
+    Examples: Test different triggers
+      | trigger          |
+      # | updated          | # Groups don't seem to receive Updated triggers
+      | changed          |
+      | received_command |

--- a/lib/openhab/dsl/monkey_patch/events/events.rb
+++ b/lib/openhab/dsl/monkey_patch/events/events.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'openhab/dsl/monkey_patch/events/item_state'
+require 'openhab/dsl/monkey_patch/events/item_event'
 require 'openhab/dsl/monkey_patch/events/item_state_changed'
 require 'openhab/dsl/monkey_patch/events/thing_status_info'
 require 'openhab/dsl/monkey_patch/events/item_command'

--- a/lib/openhab/dsl/monkey_patch/events/item_event.rb
+++ b/lib/openhab/dsl/monkey_patch/events/item_event.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'java'
+
+module OpenHAB
+  module DSL
+    module MonkeyPatch
+      #
+      # Patches OpenHAB events
+      #
+      module Events
+        java_import Java::OrgOpenhabCoreItemsEvents::ItemEvent
+
+        #
+        # MonkeyPatch to add item
+        #
+        class ItemEvent
+          #
+          # Return a decorated item
+          #
+          def item
+            OpenHAB::Core::EntityLookup.lookup_item(item_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openhab/dsl/monkey_patch/events/item_state_changed.rb
+++ b/lib/openhab/dsl/monkey_patch/events/item_state_changed.rb
@@ -15,17 +15,6 @@ module OpenHAB
         # MonkeyPatch with ruby style accessors
         #
         class ItemStateChangedEvent
-          #
-          # Get the item that caused the state change
-          #
-          # @return [Item] Item that caused state change
-          #
-          def item
-            # rubocop:disable Style/GlobalVars
-            $ir.get(item_name)
-            # rubocop:enable Style/GlobalVars
-          end
-
           alias state item_state
           alias last old_item_state
         end

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -244,21 +244,6 @@ module OpenHAB
         end
 
         #
-        # Patch event to decorate event.item with our item wrapper
-        #
-        # @param [OpenHAB Event] event patch
-        #
-        def decorate_event_item(event)
-          return if event.nil?
-
-          class << event
-            def item
-              OpenHAB::Core::EntityLookup.lookup_item(item_name)
-            end
-          end
-        end
-
-        #
         # Process the run queue
         #
         # @param [Array] run_queue array of procs of various types to execute
@@ -287,7 +272,6 @@ module OpenHAB
         #
         #
         def process_otherwise_task(event, task)
-          decorate_event_item(event)
           logger.trace { "Executing rule '#{name}' otherwise block with event(#{event})" }
           task.block.call(event)
         end
@@ -314,9 +298,10 @@ module OpenHAB
         #
         #
         def process_trigger_task(event, task)
-          triggering_item = OpenHAB::Core::EntityLookup.lookup_item(event&.itemName)
-          logger.trace { "Executing rule '#{name}' trigger block with item (#{triggering_item})" }
-          task.block.call(triggering_item) if triggering_item
+          return unless event&.item
+
+          logger.trace { "Executing rule '#{name}' trigger block with item (#{event.item})" }
+          task.block.call(event.item)
         end
 
         #
@@ -327,7 +312,6 @@ module OpenHAB
         #
         #
         def process_run_task(event, task)
-          decorate_event_item(event)
           logger.trace { "Executing rule '#{name}' run block with event(#{event})" }
           task.block.call(event)
         end


### PR DESCRIPTION
Resolve #189 

Instead of looking up and decorating items every time a run / triggered block is encountered, which can occur multiple times when there are multiple run/trigger blocks, the lookup and decoration is done only once in the monkey patched event.