### PR TITLE
feat(persistence): ability to set a default persistence service for the script

### DIFF
--- a/docs/usage/misc/persistence.md
+++ b/docs/usage/misc/persistence.md
@@ -47,10 +47,10 @@ Number:Power  Power_Usage "Power Usage [%.2f W]"
 
 ```ruby
 # UV_Index average will return a DecimalType
-logger.info("UV_Index Average: #{UV_Index.average_since(12.hours)}") 
+logger.info("UV_Index Average: #{UV_Index.average_since(12.hours, :influxdb)}") 
 # Power_Usage has a Unit of Measurement, so 
 # Power_Usage.average_since will return a Quantity with the same unit
-logger.info("Power_Usage Average: #{Power_Usage.average_since(12.hours)}") 
+logger.info("Power_Usage Average: #{Power_Usage.average_since(12.hours, :influxdb)}") 
 ```
 
 Comparison using Quantity
@@ -81,5 +81,27 @@ persistence(:influxdb) do
   Item1.persist
   Item1.changed_since(1.hour)
   Item1.average_since(12.hours)
+end
+```
+
+## Setting The Default Persistence Service
+
+The default persistence service can be set at the beginning of the execution block (run, triggered, otherwise), and it will affect all persistence operations within that block, unless a specific service is specified in the argument or within a persistence block.
+
+Note that this does not alter the system-wide default persistence service that is configured 
+on the OpenHAB installation. This simply affects the current execution block.
+
+To specify the default persistence service, call the `def_default_persistence` function at the beginning
+of the execution block. Example:
+
+```ruby
+require 'openhab'
+
+rule 'Test rule' do
+  on_start
+  run do
+    def_default_persistence :influxdb
+    logger.info("Item1's last_update: #{Item1.last_update}") 
+  end
 end
 ```

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -78,3 +78,26 @@ Feature: persistence
       """
     When I deploy the rule
     Then It should log 'Average: 3 kW' within 10 seconds
+
+  Scenario: Set default persistence
+    Given items:
+      | type         | name         | label | pattern | state |
+      | Number:Power | Number_Power | Power | %.1f kW | 2 kW  |
+    And code in a rules file:
+      """
+      rule 'use default persistence service' do
+        on_start
+        run { logger.info("Without Default Average: '#{Number_Power.average_since(10.seconds)}'") }
+      end
+
+      rule 'use default persistence service' do
+        on_start
+        run do
+          def_default_persistence :mapdb
+          logger.info("With Default Average: '#{Number_Power.average_since(10.seconds)}'")
+        end
+      end
+      """
+    When I deploy the rule
+    Then It should log "With Default Average: '2 kW'" within 5 seconds
+    And It should log "Without Default Average: ''" within 5 seconds

--- a/lib/openhab/dsl/persistence.rb
+++ b/lib/openhab/dsl/persistence.rb
@@ -15,10 +15,20 @@ module OpenHAB
       #
       #
       def persistence(service)
+        previous_persistence = Thread.current.thread_variable_get(:persistence_service)
         Thread.current.thread_variable_set(:persistence_service, service)
         yield
       ensure
-        Thread.current.thread_variable_set(:persistence_service, nil)
+        Thread.current.thread_variable_set(:persistence_service, previous_persistence)
+      end
+
+      #
+      # Sets the default persistence for the script
+      #
+      # @param [Object] service service either as a String or a Symbol
+      #
+      def def_default_persistence(service)
+        Thread.current.thread_variable_set(:persistence_service, service)
       end
     end
   end


### PR DESCRIPTION
This PR adds `def_default_persistence` function as an alternative to using a persistence block.
It can still be overridden by a persistence block should it be required.

Example:

```ruby
require 'openhab'

rule 'Test rule' do
  on_start
  run do
    def_default_persistence :influxdb
    logger.info("Item1's last_update: #{Item1.last_update.is_after(Item2.last_update}") } # Both calls will use :influxdb
  end
end
```
