### PR TITLE
perf(logging): use block syntax to log method calls

### DIFF
--- a/lib/openhab/dsl/monkey_patch/items/metadata.rb
+++ b/lib/openhab/dsl/monkey_patch/items/metadata.rb
@@ -103,8 +103,7 @@ module OpenHAB
             # @return [OpenHAB::DSL::MonkeyPatch::Items::MetadataItem], or nil if the namespace doesn't exist
             #
             def [](namespace)
-              logger.trace("Namespaces (#{NamespaceAccessor.registry.getAll})")
-              logger.trace("Namespace (#{NamespaceAccessor.registry.get(MetadataKey.new(namespace, @item_name))})")
+              logger.trace("Getting metadata for item: #{@item_name}, namespace '#{namespace}'")
               metadata = NamespaceAccessor.registry.get(MetadataKey.new(namespace, @item_name))
               MetadataItem.new(metadata: metadata) if metadata
             end

--- a/lib/openhab/dsl/rules/guard.rb
+++ b/lib/openhab/dsl/rules/guard.rb
@@ -79,7 +79,7 @@ module OpenHAB
             procs, items = conditions.flatten.partition { |condition| condition.is_a? Proc }
             logger.trace("Procs: #{procs} Items: #{items}")
 
-            items.each { |item| logger.trace("#{item} truthy? #{item.truthy?}") }
+            items.each { |item| logger.trace { "#{item} truthy? #{item.truthy?}" } }
 
             process_check(check_type: check_type, event: event, items: items, procs: procs)
           end

--- a/lib/openhab/dsl/types/quantity.rb
+++ b/lib/openhab/dsl/types/quantity.rb
@@ -144,8 +144,10 @@ module OpenHAB
 
         OPERATIONS.each do |operation, method|
           define_method(operation) do |other|
-            logger.trace("Executing math operation '#{operation}' on quantity #{inspect} "\
-                         "with other type #{other.class} and value #{other.inspect}")
+            logger.trace do
+              "Executing math operation '#{operation}' on quantity #{inspect} "\
+                         "with other type #{other.class} and value #{other.inspect}"
+            end
 
             a, b = to_qt(coerce(other).reverse)
             logger.trace("Coerced a='#{a}' with b='#{b}'")


### PR DESCRIPTION
I went through the library and only found these three instances where logging could be further optimised
Resolve #194 