### PR TITLE
refactor(hash): use hashrockets for hashes that have keys as values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
 
+Style/HashSyntax:
+  UseHashRocketsWithSymbolValues: true
+

--- a/features/step_definitions/openhab_rules.rb
+++ b/features/step_definitions/openhab_rules.rb
@@ -77,7 +77,7 @@ When('I deploy a rule with an error') do
 end
 
 When('I start deploying the rule') do
-  deploy_rule(check_position: :start)
+  deploy_rule(:check_position => :start)
 end
 
 Given('code in a rules file(:)') do |doc_string|

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -12,7 +12,7 @@ end
 
 def openhab_client(command)
   karaf_client_path = File.join(openhab_dir, 'runtime/bin/client')
-  cmd = TTY::Command.new(printer: :null)
+  cmd = TTY::Command.new(:printer => :null)
   cmd.run("#{karaf_client_path} -p habopen #{command}", only_output_on_error: true)
 end
 
@@ -50,7 +50,7 @@ def clear_gem_path
 end
 
 def ensure_openhab_running
-  cmd = TTY::Command.new(printer: :null)
+  cmd = TTY::Command.new(:printer => :null)
   cmd.run(File.join(openhab_dir, 'runtime/bin/status'), only_output_on_error: true)
 end
 

--- a/features/support/openhab_rest.rb
+++ b/features/support/openhab_rest.rb
@@ -32,7 +32,7 @@ class Rest
   end
 
   def self.item_state(name)
-    (get "/rest/items/#{name}/state", headers: text, format: :text).chomp
+    (get "/rest/items/#{name}/state", :headers => text, :format => :text).chomp
   end
 
   def self.delete_item(name)

--- a/lib/openhab/dsl/items/player_item.rb
+++ b/lib/openhab/dsl/items/player_item.rb
@@ -18,8 +18,10 @@ module OpenHAB
 
         def_item_delegator :@player_item
 
-        item_type Java::OrgOpenhabCoreLibraryItems::PlayerItem, play?: :playing?, pause?: :paused?,
-                                                                rewind?: :rewinding?, fastforward?: :fastforwarding?
+        item_type Java::OrgOpenhabCoreLibraryItems::PlayerItem, :play? => :playing?,
+                                                                :pause? => :paused?,
+                                                                :rewind? => :rewinding?,
+                                                                :fastforward? => :fastforwarding?
 
         # rubocop: disable Style/Alias
         # Disabled because 'alias' does not work with the dynamically defined methods

--- a/lib/openhab/dsl/rules/guard.rb
+++ b/lib/openhab/dsl/rules/guard.rb
@@ -59,7 +59,8 @@ module OpenHAB
           #
           def should_run?(event)
             logger.trace("Checking guards #{self}")
-            check(@only_if, check_type: :only_if, event: event) && check(@not_if, check_type: :not_if, event: event)
+            check(@only_if, :check_type => :only_if,
+                            :event => event) && check(@not_if, :check_type => :not_if, :event => event)
           end
 
           private

--- a/lib/openhab/dsl/rules/rule_config.rb
+++ b/lib/openhab/dsl/rules/rule_config.rb
@@ -62,10 +62,10 @@ module OpenHAB
         #
         Delay = Struct.new(:duration)
 
-        prop_array :run, array_name: :run_queue, wrapper: Run
-        prop_array :triggered, array_name: :run_queue, wrapper: Trigger
-        prop_array :delay, array_name: :run_queue, wrapper: Delay
-        prop_array :otherwise, array_name: :run_queue, wrapper: Otherwise
+        prop_array :run, :array_name => :run_queue, :wrapper => Run
+        prop_array :triggered, :array_name => :run_queue, :wrapper => Trigger
+        prop_array :delay, :array_name => :run_queue, :wrapper => Delay
+        prop_array :otherwise, :array_name => :run_queue, :wrapper => Otherwise
 
         prop :name
         prop :description

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -17,7 +17,7 @@ namespace :docs do
   end
 
   desc 'Start Jekyll Documentation Server'
-  task jeykll: :yard do
+  task :jeykll => :yard do
     sh 'bundle exec jekyll clean'
     sh 'bundle exec jekyll server --config docs/_config.yml'
   end

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -24,7 +24,7 @@ namespace :openhab do
   CLEAN << @deploy_dir
 
   def command_success?(command)
-    cmd = TTY::Command.new(printer: :null)
+    cmd = TTY::Command.new(:printer => :null)
     cmd.run!(command).success?
   end
 
@@ -49,7 +49,7 @@ namespace :openhab do
       fail_on_error("#{@karaf_client} 'system:version'")
       true
     else
-      cmd = TTY::Command.new(printer: :null)
+      cmd = TTY::Command.new(:printer => :null)
       cmd.run!("#{@karaf_client} 'system:version'").success?
     end
   end


### PR DESCRIPTION
This came up when creating the player item. 
```
 item_type Java::OrgOpenhabCoreLibraryItems::PlayerItem, play?: :playing?, pause?: :paused?,
                                                                rewind?: :rewinding?, fastforward?: :fastforwarding?
```
The colon syntax for hashes, is in my opinion, a lot less readable when both the values are symbols.
I believe that this is much more readable:
```
 item_type Java::OrgOpenhabCoreLibraryItems::PlayerItem, :play? => :playing?, :pause? => :paused?,
                                                                :rewind? => :rewinding?, :fastforward? => :fastforwarding?
```
There is an option in rubocop to use and enforce this style which this PR does.

See this issue for more discussion: https://github.com/rubocop/rubocop/issues/1437


Any issues @jimtng or @pacive ?

