### PR TITLE
feat(persistence): support TimeOfDay as the timestamp for persistence methods

### DIFF
--- a/docs/usage/misc/persistence.md
+++ b/docs/usage/misc/persistence.md
@@ -28,7 +28,7 @@ grand_parent: Usage
 | `updated_since`   | timestamp, service                    |                                                                 |
 | `variance_since`  | timestamp, service                    |                                                                 |
 
-* The `timestamp` parameter accepts a java ZonedDateTime or a [Duration](../duration/) object that specifies how far back in time.
+* The `timestamp` parameter accepts a java ZonedDateTime, a [Duration](../duration/) object that specifies how far back in time, or a [TimeOfDay](../time_of_day/) string or object that represents the time of day today. `TimeOfDay` constants such as `MIDNIGHT` and `NOON` can be used.
 * The `service` optional parameter accepts the name of the persistence service to use, as a String or Symbol. When not specified, the system's default persistence service will be used.
 * The return value of the following persistence methods is a [Quantity](../../items/number/#quantities) when the corresponding item is a dimensioned NumberItem:
   * `average_since`
@@ -50,7 +50,8 @@ Number:Power  Power_Usage "Power Usage [%.2f W]"
 logger.info("UV_Index Average: #{UV_Index.average_since(12.hours)}") 
 # Power_Usage has a Unit of Measurement, so 
 # Power_Usage.average_since will return a Quantity with the same unit
-logger.info("Power_Usage Average: #{Power_Usage.average_since(12.hours)}") 
+logger.info("Power_Usage Average: #{Power_Usage.average_since(MIDNIGHT)}") 
+logger.info("Power_Usage Average: #{Power_Usage.average_since('7am')}") 
 ```
 
 Comparison using Quantity

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -40,7 +40,7 @@ Feature: persistence
         run do
           Number1.update 10
           sleep 1
-          persistence(:rrd4j) do
+          persistence(:mapdb) do
             Number1.persist
             Test_Group.persist
             logger.info("Last update: #{Number1.last_update}")
@@ -77,8 +77,8 @@ Feature: persistence
       | Number:Power | Max_Power | Max Power | %.1f kW | MAX      |
 
     And items:
-      | type         | name         | label | pattern | state | groups     |
-      | Number:Power | Number_Power | Power | %.1f kW | 0 kW  | Max_Power  |
+      | type         | name         | label | pattern | state | groups    |
+      | Number:Power | Number_Power | Power | %.1f kW | 0 kW  | Max_Power |
 
     And code in a rules file:
       """
@@ -95,3 +95,18 @@ Feature: persistence
     When I deploy the rule
     Then It should log 'Average: 3 kW' within 10 seconds
     And It should log 'Average Max: 3 kW' within 10 seconds
+
+  Scenario Outline: Persistence supports various types of timestamp
+    Given code in a rules file:
+      """
+      logger.info("Updated since <since>: #{Number1.updated_since(<since>, :mapdb)}")
+      """
+    When I deploy the rule
+    Then It should log "Updated since <since>: " within 5 seconds
+    Examples:
+      | since                           |
+      | ZonedDateTime.now.minusHours(1) |
+      | MIDNIGHT                        |
+      | NOON                            |
+      | '6am'                           |
+      | 1.hour                          |

--- a/lib/openhab/dsl/monkey_patch/items/persistence.rb
+++ b/lib/openhab/dsl/monkey_patch/items/persistence.rb
@@ -66,11 +66,14 @@ module OpenHAB
           # @return [ZonedDateTime]
           #
           def to_zdt(timestamp)
-            if timestamp.is_a? Java::JavaTimeTemporal::TemporalAmount
-              logger.trace("Converting #{timestamp} (#{timestamp.class}) to ZonedDateTime")
-              Java::JavaTime::ZonedDateTime.now.minus(timestamp)
-            else
-              timestamp
+            logger.trace("Converting #{timestamp} (#{timestamp.class}) to ZonedDateTime")
+            return timestamp.to_zdt if timestamp.respond_to? :to_zdt
+
+            case timestamp
+            when ZonedDateTime then timestamp
+            when Java::JavaTimeTemporal::TemporalAmount then ZonedDateTime.now.minus(timestamp)
+            when String then OpenHAB::DSL::TimeOfDay::TimeOfDay.parse(timestamp).to_zdt
+            else raise ArgumentError, "Invalid timestamp: #{timestamp} (#{timestamp.class})"
             end
           end
 

--- a/lib/openhab/dsl/time_of_day.rb
+++ b/lib/openhab/dsl/time_of_day.rb
@@ -110,6 +110,15 @@ module OpenHAB
           @local_time.to_s
         end
 
+        #
+        # Fill in today's date and return a ZonedDateTime object
+        #
+        # @return [ZonedDateTime] Today's date + the time represented by this object
+        #
+        def to_zdt
+          ZonedDateTime.now.withHour(hour).withMinute(minute).withSecond(second).withNano(0)
+        end
+
         # Compares one TimeOfDay to another
         # @since 0.0.1
         # @return [Number, nil] -1,0,1 if other TimeOfDay is less than, equal to, or greater than this TimeOfDay


### PR DESCRIPTION
As mentioned in #208 this PR supports this code:

```ruby
Solar_AC_Power.maximum_since(MIDNIGHT) #this uses our MIDNIGHT constant from time_of_day.rb
Solar_AC_Power.maximum_since('7am')
```