### PR TITLE
feat: support more comparisons

### DIFF
--- a/features/comparisons.feature
+++ b/features/comparisons.feature
@@ -13,31 +13,25 @@ Feature: comparisons
       | ShuttersPos  | Rollershutter      | MAX      |              |
 
     And items:
-      | type               | name       | label         | group | state |
-      | Number             | Number5    | Number Five   |       | 5     |
-      | Number             | Number10   | Number Ten    |       | 10    |
-      | Number             | Number10A  | Number Ten A  |       | 10    |
-      | Number             | Number20   | Number Twenty |       | 20    |
-      | Number:Temperature | Number5C   | Number Five   |       | 5°C   |
-      | Number:Temperature | Number10C  | Number Ten    |       | 10°C  |
-      | Number:Temperature | Number10C2 | Number Ten    |       | 10°C  |
-      | Number:Temperature | Number20C  | Number Twenty |       | 20°C  |
-      | Dimmer             | Dimmer5    | Dimmer Five   |       | 5     |
-      | Dimmer             | Dimmer10   | Dimmer Ten    |       | 10    |
-
-    And items:
-      | type               | name            | label                   | state                     | groups                |
-      | Number:Temperature | Livingroom_Temp | Living Room temperature | 70 °F                     | Temperatures          |
-      | Number:Temperature | Bedroom_Temp    | Bedroom temperature     | 50 °F                     | Temperatures          |
-      | Number:Temperature | Den_Temp        | Den temperature         | 30 °F                     | Temperatures          |
-      | Switch             | SwitchOne       | Switch One              | ON                        | Switches              |
-      | Switch             | SwitchTwo       | Switch Two              | OFF                       | Switches              |
-      | Contact            | ContactOne      | Contact One             | OPEN                      | Contacts              |
-      | Contact            | ContactTwo      | Contact Two             | CLOSED                    | Contacts              |
-      | DateTime           | DateOne         | Date One                | 2021-01-01T00:00:00+00:00 | Dates                 |
-      | DateTime           | DateTwo         | Date Two                | 2021-02-01T12:00:00+00:00 | Dates                 |
-      | Rollershutter      | ShutterOne      | Shutter One             | 0                         | Shutters, ShuttersPos |
-      | Rollershutter      | ShutterTwo      | Shutter Two             | 50                        | Shutters, ShuttersPos |
+      | type               | name            | label                   | groups                | state                     |
+      | Number             | Number5         | Number Five             |                       | 5                         |
+      | Number             | Number10        | Number Ten              |                       | 10                        |
+      | Number             | Number10A       | Number Ten A            |                       | 10                        |
+      | Number             | Number20        | Number Twenty           |                       | 20                        |
+      | Number:Temperature | Number5C        | Number Five             | Temperatures          | 5°C                       |
+      | Number:Temperature | Number10C       | Number Ten              | Temperatures          | 10°C                      |
+      | Number:Temperature | Number10C2      | Number Ten              | Temperatures          | 10°C                      |
+      | Number:Temperature | Number20C       | Number Twenty           | Temperatures          | 20°C                      |
+      | Dimmer             | Dimmer5         | Dimmer Five             |                       | 5                         |
+      | Dimmer             | Dimmer10        | Dimmer Ten              |                       | 10                        |
+      | Switch             | SwitchOne       | Switch One              | Switches              | ON                        |
+      | Switch             | SwitchTwo       | Switch Two              | Switches              | OFF                       |
+      | Contact            | ContactOne      | Contact One             | Contacts              | OPEN                      |
+      | Contact            | ContactTwo      | Contact Two             | Contacts              | CLOSED                    |
+      | DateTime           | DateOne         | Date One                | Dates                 | 2021-01-01T00:00:00+00:00 |
+      | DateTime           | DateTwo         | Date Two                | Dates                 | 2021-02-01T12:00:00+00:00 |
+      | Rollershutter      | ShutterOne      | Shutter One             | Shutters, ShuttersPos | 0                         |
+      | Rollershutter      | ShutterTwo      | Shutter Two             | Shutters, ShuttersPos | 50                        |
 
   Scenario: Comparisons can be done against different types
     Given code in a rules file
@@ -48,337 +42,361 @@ Feature: comparisons
       #comparison pairs
       tests = [
         # NumberItem vs NumberItem
-        [ Number10                   , '==' , Number10A                  , true  ]  ,
-        [ Number10                   , '==' , Number5                    , false ]  ,
-        [ Number10                   , '!=' , Number5                    , true  ]  ,
-        [ Number10                   , '!=' , Number10A                  , false ]  ,
+        [ Number10                    , '==' , Number10A                   , true  ]  ,
+        [ Number10                    , '==' , Number5                     , false ]  ,
+        [ Number10                    , '!=' , Number5                     , true  ]  ,
+        [ Number10                    , '!=' , Number10A                   , false ]  ,
 
-        [ Number10                   , '<'  , Number20                   , true  ]  ,
-        [ Number10                   , '<'  , Number5                    , false ]  ,
-        [ Number10                   , '>'  , Number5                    , true  ]  ,
-        [ Number10                   , '>'  , Number20                   , false ]  ,
+        [ Number10                    , '<'  , Number20                    , true  ]  ,
+        [ Number10                    , '<'  , Number5                     , false ]  ,
+        [ Number10                    , '>'  , Number5                     , true  ]  ,
+        [ Number10                    , '>'  , Number20                    , false ]  ,
 
         # NumberItem vs Ruby Numeric
-        [ Number10                   , '==' , 10                         , true  ]  ,
-        [ Number10                   , '==' , 1                          , false ]  ,
-        [ Number10                   , '!=' , 1                          , true  ]  ,
-        [ Number10                   , '!=' , 10                         , false ]  ,
+        [ Number10                    , '==' , 10                          , true  ]  ,
+        [ Number10                    , '==' , 1                           , false ]  ,
+        [ Number10                    , '!=' , 1                           , true  ]  ,
+        [ Number10                    , '!=' , 10                          , false ]  ,
 
-        [ Number10                   , '<'  , 10.1                       , true  ]  ,
-        [ Number10                   , '<'  , 5                          , false ]  ,
-        [ Number10                   , '>'  , 5                          , true  ]  ,
-        [ Number10                   , '>'  , 10.1                       , false ]  ,
+        [ Number10                    , '<'  , 10.1                        , true  ]  ,
+        [ Number10                    , '<'  , 5                           , false ]  ,
+        [ Number10                    , '>'  , 5                           , true  ]  ,
+        [ Number10                    , '>'  , 10.1                        , false ]  ,
 
         # Ruby Numeric vs NumberItem
-        [ 10                         , '==' , Number10                   , true  ]  ,
-        [ 10                         , '==' , Number5                    , false ]  ,
-        [ 10                         , '!=' , Number5                    , true  ]  ,
-        [ 10                         , '!=' , Number10                   , false ]  ,
+        [ 10                          , '==' , Number10                    , true  ]  ,
+        [ 10                          , '==' , Number5                     , false ]  ,
+        [ 10                          , '!=' , Number5                     , true  ]  ,
+        [ 10                          , '!=' , Number10                    , false ]  ,
 
-        [ 10.5                       , '<'  , Number20                   , true  ]  ,
-        [ 10                         , '<'  , Number5                    , false ]  ,
-        [ 10                         , '>'  , Number5                    , true  ]  ,
-        [ 10                         , '>'  , Number10                   , false ]  ,
+        [ 10.5                        , '<'  , Number20                    , true  ]  ,
+        [ 10                          , '<'  , Number5                     , false ]  ,
+        [ 10                          , '>'  , Number5                     , true  ]  ,
+        [ 10                          , '>'  , Number10                    , false ]  ,
 
         # NumberItem vs DimmerItem
-        [ Number10                   , '==' , Dimmer10                   , true  ]  ,
-        [ Number10                   , '==' , Dimmer5                    , false ]  ,
-        [ Number10                   , '!=' , Dimmer5                    , true  ]  ,
-        [ Number10                   , '!=' , Dimmer10                   , false ]  ,
+        [ Number10                    , '==' , Dimmer10                    , true  ]  ,
+        [ Number10                    , '==' , Dimmer5                     , false ]  ,
+        [ Number10                    , '!=' , Dimmer5                     , true  ]  ,
+        [ Number10                    , '!=' , Dimmer10                    , false ]  ,
 
-        [ Number5                    , '<'  , Dimmer10                   , true  ]  ,
-        [ Number10                   , '<'  , Dimmer5                    , false ]  ,
-        [ Number10                   , '>'  , Dimmer5                    , true  ]  ,
-        [ Number5                    , '>'  , Dimmer10                   , false ]  ,
+        [ Number5                     , '<'  , Dimmer10                    , true  ]  ,
+        [ Number10                    , '<'  , Dimmer5                     , false ]  ,
+        [ Number10                    , '>'  , Dimmer5                     , true  ]  ,
+        [ Number5                     , '>'  , Dimmer10                    , false ]  ,
 
         # DimmerItem vs NumberItem
-        [ Dimmer10                   , '==' , Number10                   , true  ]  ,
-        [ Dimmer10                   , '==' , Number5                    , false ]  ,
-        [ Dimmer10                   , '!=' , Number5                    , true  ]  ,
-        [ Dimmer10                   , '!=' , Number10                   , false ]  ,
+        [ Dimmer10                    , '==' , Number10                    , true  ]  ,
+        [ Dimmer10                    , '==' , Number5                     , false ]  ,
+        [ Dimmer10                    , '!=' , Number5                     , true  ]  ,
+        [ Dimmer10                    , '!=' , Number10                    , false ]  ,
 
-        [ Dimmer10                   , '<'  , Number20                   , true  ]  ,
-        [ Dimmer10                   , '<'  , Number5                    , false ]  ,
-        [ Dimmer10                   , '>'  , Number5                    , true  ]  ,
-        [ Dimmer10                   , '>'  , Number20                   , false ]  ,
+        [ Dimmer10                    , '<'  , Number20                    , true  ]  ,
+        [ Dimmer10                    , '<'  , Number5                     , false ]  ,
+        [ Dimmer10                    , '>'  , Number5                     , true  ]  ,
+        [ Dimmer10                    , '>'  , Number20                    , false ]  ,
 
         # NumberItem's state vs DimmerItem's state
-        [ Number10.state             , '==' , Dimmer10.state             , true  ]  ,
-        [ Number5.state              , '==' , Dimmer10.state             , false ]  ,
-        [ Number5.state              , '!=' , Dimmer10.state             , true  ]  ,
-        [ Number10.state             , '!=' , Dimmer10.state             , false ]  ,
+        [ Number10.state              , '==' , Dimmer10.state              , true  ]  ,
+        [ Number5.state               , '==' , Dimmer10.state              , false ]  ,
+        [ Number5.state               , '!=' , Dimmer10.state              , true  ]  ,
+        [ Number10.state              , '!=' , Dimmer10.state              , false ]  ,
 
         # DimmerItem vs Ruby Numeric
-        [ Dimmer10                   , '==' , 10                         , true  ]  ,
-        [ Dimmer10                   , '==' , 10.1                       , false ]  ,
-        [ Dimmer10                   , '!=' , 2                          , true  ]  ,
-        [ Dimmer10                   , '!=' , 10                         , false ]  ,
+        [ Dimmer10                    , '==' , 10                          , true  ]  ,
+        [ Dimmer10                    , '==' , 10.1                        , false ]  ,
+        [ Dimmer10                    , '!=' , 2                           , true  ]  ,
+        [ Dimmer10                    , '!=' , 10                          , false ]  ,
 
-        [ Dimmer10                   , '<'  , 20                         , true  ]  ,
-        [ Dimmer10                   , '<'  , 5                          , false ]  ,
-        [ Dimmer10                   , '>'  , 5                          , true  ]  ,
-        [ Dimmer10                   , '>'  , 20                         , false ]  ,
+        [ Dimmer10                    , '<'  , 20                          , true  ]  ,
+        [ Dimmer10                    , '<'  , 5                           , false ]  ,
+        [ Dimmer10                    , '>'  , 5                           , true  ]  ,
+        [ Dimmer10                    , '>'  , 20                          , false ]  ,
 
         # Ruby Numeric vs DimmerItem
-        [ 10                         , '==' , Dimmer10                   , true  ]  ,
-        [ 10.1                       , '==' , Dimmer10                   , false ]  ,
-        [ 2                          , '!=' , Dimmer10                   , true  ]  ,
-        [ 10                         , '!=' , Dimmer10                   , false ]  ,
+        [ 10                          , '==' , Dimmer10                    , true  ]  ,
+        [ 10.1                        , '==' , Dimmer10                    , false ]  ,
+        [ 2                           , '!=' , Dimmer10                    , true  ]  ,
+        [ 10                          , '!=' , Dimmer10                    , false ]  ,
 
-        [ 5                          , '<'  , Dimmer10                   , true  ]  ,
-        [ 20                         , '<'  , Dimmer10                   , false ]  ,
-        [ 11                         , '>'  , Dimmer10                   , true  ]  ,
-        [ 5                          , '>'  , Dimmer10                   , false ]  ,
+        [ 5                           , '<'  , Dimmer10                    , true  ]  ,
+        [ 20                          , '<'  , Dimmer10                    , false ]  ,
+        [ 11                          , '>'  , Dimmer10                    , true  ]  ,
+        [ 5                           , '>'  , Dimmer10                    , false ]  ,
 
         # NumberItem with UoM vs another
-        [ Number10C                  , '==' , Number10C2                 , true  ]  ,
-        [ Number10C                  , '!=' , Number10C2                 , false ]  ,
+        [ Number10C                   , '==' , Number10C2                  , true  ]  ,
+        [ Number10C                   , '!=' , Number10C2                  , false ]  ,
+
+        # NumberItem with UoM vs String
+        [ Number10C                   , '>'  , '4 °F'                      , true  ]  ,
+        [ Number10C                   , '==' , '10 °C'                     , true  ]  ,
 
         # NumberItem with UoM vs QuantityType
-        [ Number10C                  , '==' , QuantityType.new('10°C')   , true  ]  ,
-        [ Number10C                  , '==' , QuantityType.new('10°F')   , false ]  ,
-        [ Number10C                  , '==' , QuantityType.new('50°F')   , true  ]  ,
-        [ Number10C                  , '!=' , QuantityType.new('10°F')   , true  ]  ,
-        [ Number10C                  , '!=' , QuantityType.new('10.1°C') , true  ]  ,
-        [ Number10C                  , '!=' , QuantityType.new('50°F')   , false ]  ,
+        [ Number10C                   , '==' , QuantityType.new('10°C')    , true  ]  ,
+        [ Number10C                   , '==' , QuantityType.new('10°F')    , false ]  ,
+        [ Number10C                   , '==' , QuantityType.new('50°F')    , true  ]  ,
+        [ Number10C                   , '!=' , QuantityType.new('10°F')    , true  ]  ,
+        [ Number10C                   , '!=' , QuantityType.new('10.1°C')  , true  ]  ,
+        [ Number10C                   , '!=' , QuantityType.new('50°F')    , false ]  ,
 
-        [ Number10C                  , '>'  , QuantityType.new('5°C')    , true  ]  ,
-        [ Number10C                  , '>'  , QuantityType.new('10°F')   , true  ]  ,
-        [ Number10C                  , '>'  , QuantityType.new('50°F')   , false ]  ,
-        [ Number5C                   , '<'  , QuantityType.new('10°C')   , true  ]  ,
-        [ Number20C                  , '<'  , QuantityType.new('10°C')   , false ]  ,
-        [ Number5C                   , '<'  , QuantityType.new('50°F')   , true  ]  ,
+        [ Number10C                   , '>'  , QuantityType.new('5°C')     , true  ]  ,
+        [ Number10C                   , '>'  , QuantityType.new('10°F')    , true  ]  ,
+        [ Number10C                   , '>'  , QuantityType.new('50°F')    , false ]  ,
+        [ Number5C                    , '<'  , QuantityType.new('10°C')    , true  ]  ,
+        [ Number20C                   , '<'  , QuantityType.new('10°C')    , false ]  ,
+        [ Number5C                    , '<'  , QuantityType.new('50°F')    , true  ]  ,
 
         # QuantityType vs NumberItem with UoM
-        [ QuantityType.new('10°C')   , '==' , Number10C                  , true  ]  ,
-        [ QuantityType.new('50°F')   , '==' , Number10C                  , true  ]  ,
-        [ QuantityType.new('10°F')   , '==' , Number10C                  , false ]  ,
-        [ QuantityType.new('10°C')   , '==' , Number20C                  , false ]  ,
+        [ QuantityType.new('10°C')    , '==' , Number10C                   , true  ]  ,
+        [ QuantityType.new('50°F')    , '==' , Number10C                   , true  ]  ,
+        [ QuantityType.new('10°F')    , '==' , Number10C                   , false ]  ,
+        [ QuantityType.new('10°C')    , '==' , Number20C                   , false ]  ,
 
 
-        [ QuantityType.new('10°F')   , '!=' , Number10C                  , true  ]  ,
-        [ QuantityType.new('10.1°C') , '!=' , Number10C                  , true  ]  ,
-        [ QuantityType.new('50°F')   , '!=' , Number10C                  , false ]  ,
-        [ QuantityType.new('10°C')   , '!=' , Number10C                  , false ]  ,
+        [ QuantityType.new('10°F')    , '!=' , Number10C                   , true  ]  ,
+        [ QuantityType.new('10.1°C')  , '!=' , Number10C                   , true  ]  ,
+        [ QuantityType.new('50°F')    , '!=' , Number10C                   , false ]  ,
+        [ QuantityType.new('10°C')    , '!=' , Number10C                   , false ]  ,
 
-        [ QuantityType.new('50°C')   , '>'  , Number10C                  , true  ]  ,
-        [ QuantityType.new('10°F')   , '>'  , Number10C                  , false ]  ,
-        [ QuantityType.new('50°F')   , '>'  , Number10C                  , false ]  ,
-        [ QuantityType.new('10°C')   , '<'  , Number20C                  , true  ]  ,
-        [ QuantityType.new('10°C')   , '<'  , Number5C                   , false ]  ,
-        [ QuantityType.new('50°F')   , '<'  , Number20C                  , true  ]  ,
+        [ QuantityType.new('50°C')    , '>'  , Number10C                   , true  ]  ,
+        [ QuantityType.new('10°F')    , '>'  , Number10C                   , false ]  ,
+        [ QuantityType.new('50°F')    , '>'  , Number10C                   , false ]  ,
+        [ QuantityType.new('10°C')    , '<'  , Number20C                   , true  ]  ,
+        [ QuantityType.new('10°C')    , '<'  , Number5C                    , false ]  ,
+        [ QuantityType.new('50°F')    , '<'  , Number20C                   , true  ]  ,
 
         # NumberItem vs PercentType
-        [ Number10                   , '==' , PercentType.new(10)        , true  ]  ,
-        [ Number5                    , '==' , PercentType.new(10)        , false ]  ,
-        [ Number5                    , '!=' , PercentType.new(10)        , true  ]  ,
-        [ Number10                   , '!=' , PercentType.new(10)        , false ]  ,
+        [ Number10                    , '==' , PercentType.new(10)         , true  ]  ,
+        [ Number5                     , '==' , PercentType.new(10)         , false ]  ,
+        [ Number5                     , '!=' , PercentType.new(10)         , true  ]  ,
+        [ Number10                    , '!=' , PercentType.new(10)         , false ]  ,
 
-        [ Number5                    , '<'  , PercentType.new(10)        , true  ]  ,
-        [ Number20                   , '<'  , PercentType.new(10)        , false ]  ,
-        [ Number20                   , '>'  , PercentType.new(10)        , true  ]  ,
-        [ Number5                    , '>'  , PercentType.new(10)        , false ]  ,
+        [ Number5                     , '<'  , PercentType.new(10)         , true  ]  ,
+        [ Number20                    , '<'  , PercentType.new(10)         , false ]  ,
+        [ Number20                    , '>'  , PercentType.new(10)         , true  ]  ,
+        [ Number5                     , '>'  , PercentType.new(10)         , false ]  ,
 
         # PercentType vs NumberItem
-        [ PercentType.new(10)        , '==' , Number10                   , true  ]  ,
-        [ PercentType.new(10)        , '==' , Number5                    , false ]  ,
-        [ PercentType.new(10)        , '!=' , Number5                    , true  ]  ,
-        [ PercentType.new(10)        , '!=' , Number10                   , false ]  ,
+        [ PercentType.new(10)         , '==' , Number10                    , true  ]  ,
+        [ PercentType.new(10)         , '==' , Number5                     , false ]  ,
+        [ PercentType.new(10)         , '!=' , Number5                     , true  ]  ,
+        [ PercentType.new(10)         , '!=' , Number10                    , false ]  ,
 
-        [ PercentType.new(10)        , '<'  , Number20                   , true  ]  ,
-        [ PercentType.new(10)        , '<'  , Number5                    , false ]  ,
-        [ PercentType.new(10)        , '>'  , Number5                    , true  ]  ,
-        [ PercentType.new(10)        , '>'  , Number20                   , false ]  ,
+        [ PercentType.new(10)         , '<'  , Number20                    , true  ]  ,
+        [ PercentType.new(10)         , '<'  , Number5                     , false ]  ,
+        [ PercentType.new(10)         , '>'  , Number5                     , true  ]  ,
+        [ PercentType.new(10)         , '>'  , Number20                    , false ]  ,
 
         # NumberItem vs DecimalType
-        [ Number10                   , '==' , DecimalType.new(10)        , true  ]  ,
-        [ Number5                    , '==' , DecimalType.new(10)        , false ]  ,
-        [ Number5                    , '!=' , DecimalType.new(10)        , true  ]  ,
-        [ Number10                   , '!=' , DecimalType.new(10)        , false ]  ,
+        [ Number10                    , '==' , DecimalType.new(10)         , true  ]  ,
+        [ Number5                     , '==' , DecimalType.new(10)         , false ]  ,
+        [ Number5                     , '!=' , DecimalType.new(10)         , true  ]  ,
+        [ Number10                    , '!=' , DecimalType.new(10)         , false ]  ,
 
-        [ Number5                    , '<'  , DecimalType.new(10)        , true  ]  ,
-        [ Number20                   , '<'  , DecimalType.new(10)        , false ]  ,
-        [ Number20                   , '>'  , DecimalType.new(10)        , true  ]  ,
-        [ Number5                    , '>'  , DecimalType.new(10)        , false ]  ,
+        [ Number5                     , '<'  , DecimalType.new(10)         , true  ]  ,
+        [ Number20                    , '<'  , DecimalType.new(10)         , false ]  ,
+        [ Number20                    , '>'  , DecimalType.new(10)         , true  ]  ,
+        [ Number5                     , '>'  , DecimalType.new(10)         , false ]  ,
 
         # DecimalType vs NumberItem
-        [ DecimalType.new(10)        , '==' , Number10                   , true  ]  ,
-        [ DecimalType.new(10)        , '==' , Number5                    , false ]  ,
-        [ DecimalType.new(10)        , '!=' , Number5                    , true  ]  ,
-        [ DecimalType.new(10)        , '!=' , Number10                   , false ]  ,
+        [ DecimalType.new(10)         , '==' , Number10                    , true  ]  ,
+        [ DecimalType.new(10)         , '==' , Number5                     , false ]  ,
+        [ DecimalType.new(10)         , '!=' , Number5                     , true  ]  ,
+        [ DecimalType.new(10)         , '!=' , Number10                    , false ]  ,
 
-        [ DecimalType.new(10)        , '<'  , Number20                   , true  ]  ,
-        [ DecimalType.new(10)        , '<'  , Number5                    , false ]  ,
-        [ DecimalType.new(10)        , '>'  , Number5                    , true  ]  ,
-        [ DecimalType.new(10)        , '>'  , Number20                   , false ]  ,
+        [ DecimalType.new(10)         , '<'  , Number20                    , true  ]  ,
+        [ DecimalType.new(10)         , '<'  , Number5                     , false ]  ,
+        [ DecimalType.new(10)         , '>'  , Number5                     , true  ]  ,
+        [ DecimalType.new(10)         , '>'  , Number20                    , false ]  ,
 
         # PercentType vs DecimalType
-        [ PercentType.new(10)        , '==' , DecimalType.new(10)        , true  ]  ,
-        [ PercentType.new(10)        , '==' , DecimalType.new(5)         , false ]  ,
-        [ PercentType.new(10)        , '!=' , DecimalType.new(5)         , true  ]  ,
-        [ PercentType.new(10)        , '!=' , DecimalType.new(10)        , false ]  ,
+        [ PercentType.new(10)         , '==' , DecimalType.new(10)         , true  ]  ,
+        [ PercentType.new(10)         , '==' , DecimalType.new(5)          , false ]  ,
+        [ PercentType.new(10)         , '!=' , DecimalType.new(5)          , true  ]  ,
+        [ PercentType.new(10)         , '!=' , DecimalType.new(10)         , false ]  ,
 
-        [ PercentType.new(10)        , '<'  , DecimalType.new(20)        , true  ]  ,
-        [ PercentType.new(10)        , '<'  , DecimalType.new(5)         , false ]  ,
-        [ PercentType.new(10)        , '>'  , DecimalType.new(5)         , TRUE  ]  ,
-        [ PercentType.new(10)        , '>'  , DecimalType.new(20)        , false ]  ,
+        [ PercentType.new(10)         , '<'  , DecimalType.new(20)         , true  ]  ,
+        [ PercentType.new(10)         , '<'  , DecimalType.new(5)          , false ]  ,
+        [ PercentType.new(10)         , '>'  , DecimalType.new(5)          , TRUE  ]  ,
+        [ PercentType.new(10)         , '>'  , DecimalType.new(20)         , false ]  ,
 
         # DecimalType vs PercentType
-        [ DecimalType.new(10)        , '==' , PercentType.new(10)        , true  ]  ,
-        [ DecimalType.new(10)        , '==' , PercentType.new(5)         , false ]  ,
-        [ DecimalType.new(10)        , '!=' , PercentType.new(5)         , true  ]  ,
-        [ DecimalType.new(10)        , '!=' , PercentType.new(10)        , false ]  ,
+        [ DecimalType.new(10)         , '==' , PercentType.new(10)         , true  ]  ,
+        [ DecimalType.new(10)         , '==' , PercentType.new(5)          , false ]  ,
+        [ DecimalType.new(10)         , '!=' , PercentType.new(5)          , true  ]  ,
+        [ DecimalType.new(10)         , '!=' , PercentType.new(10)         , false ]  ,
 
-        [ DecimalType.new(10)        , '<'  , PercentType.new(20)        , true  ]  ,
-        [ DecimalType.new(10)        , '<'  , PercentType.new(5)         , false ]  ,
-        [ DecimalType.new(10)        , '>'  , PercentType.new(5)         , TRUE  ]  ,
-        [ DecimalType.new(10)        , '>'  , PercentType.new(20)        , false ]  ,
+        [ DecimalType.new(10)         , '<'  , PercentType.new(20)         , true  ]  ,
+        [ DecimalType.new(10)         , '<'  , PercentType.new(5)          , false ]  ,
+        [ DecimalType.new(10)         , '>'  , PercentType.new(5)          , true  ]  ,
+        [ DecimalType.new(10)         , '>'  , PercentType.new(20)         , false ]  ,
 
         # QuantityType vs String with UoM
-        [ QuantityType.new('10°C')   , '==' , '10°C'                     , true  ]  ,
-        [ QuantityType.new('50°F')   , '==' , '10°C'                     , true  ]  ,
-        [ QuantityType.new('10°F')   , '==' , '10°C'                     , false ]  ,
-        [ QuantityType.new('10°C')   , '==' , '20°C'                     , false ]  ,
+        [ QuantityType.new('10°C')    , '==' , '10°C'                      , true  ]  ,
+        [ QuantityType.new('50°F')    , '==' , '10°C'                      , true  ]  ,
+        [ QuantityType.new('10°F')    , '==' , '10°C'                      , false ]  ,
+        [ QuantityType.new('10°C')    , '==' , '20°C'                      , false ]  ,
 
-        [ QuantityType.new('10°F')   , '!=' , '10°C'                     , true  ]  ,
-        [ QuantityType.new('10.1°C') , '!=' , '10°C'                     , true  ]  ,
-        [ QuantityType.new('50°F')   , '!=' , '10°C'                     , false ]  ,
-        [ QuantityType.new('10°C')   , '!=' , '10°C'                     , false ]  ,
+        [ QuantityType.new('10°F')    , '!=' , '10°C'                      , true  ]  ,
+        [ QuantityType.new('10.1°C')  , '!=' , '10°C'                      , true  ]  ,
+        [ QuantityType.new('50°F')    , '!=' , '10°C'                      , false ]  ,
+        [ QuantityType.new('10°C')    , '!=' , '10°C'                      , false ]  ,
 
-        [ QuantityType.new('50°C')   , '>'  , '10°C'                     , true  ]  ,
-        [ QuantityType.new('10°F')   , '>'  , '10°C'                     , false ]  ,
-        [ QuantityType.new('50°F')   , '>'  , '10°C'                     , false ]  ,
-        [ QuantityType.new('10°C')   , '<'  , '20°C'                     , true  ]  ,
-        [ QuantityType.new('10°C')   , '<'  , '5°C'                      , false ]  ,
-        [ QuantityType.new('50°F')   , '<'  , '20°C'                     , true  ]  ,
+        [ QuantityType.new('50°C')    , '>'  , '10°C'                      , true  ]  ,
+        [ QuantityType.new('10°F')    , '>'  , '10°C'                      , false ]  ,
+        [ QuantityType.new('50°F')    , '>'  , '10°C'                      , false ]  ,
+        [ QuantityType.new('10°C')    , '<'  , '20°C'                      , true  ]  ,
+        [ QuantityType.new('10°C')    , '<'  , '5°C'                       , false ]  ,
+        [ QuantityType.new('50°F')    , '<'  , '20°C'                      , true  ]  ,
 
         # String with UoM vs QuantityType
-        [ '10°C'                     , '==' , QuantityType.new('10°C')   , true  ]  ,
-        [ '10°C'                     , '==' , QuantityType.new('50°F')   , true  ]  ,
-        [ '10°C'                     , '==' , QuantityType.new('10°F')   , false ]  ,
-        [ '20°C'                     , '==' , QuantityType.new('10°C')   , false ]  ,
-        [ '10°C'                     , '!=' , QuantityType.new('10°F')   , true  ]  ,
-        [ '10°C'                     , '!=' , QuantityType.new('10.1°C') , true  ]  ,
-        [ '10°C'                     , '!=' , QuantityType.new('50°F')   , false ]  ,
-        [ '10°C'                     , '!=' , QuantityType.new('10°C')   , false ]  ,
-        [ '10°C'                     , '<'  , QuantityType.new('50°C')   , true  ]  ,
-        [ '10°C'                     , '<'  , QuantityType.new('10°F')   , false ]  ,
-        [ '10°C'                     , '<'  , QuantityType.new('50°F')   , false ]  ,
-        [ '20°C'                     , '>'  , QuantityType.new('10°C')   , true  ]  ,
-        [ '5°C'                      , '>'  , QuantityType.new('10°C')   , false ]  ,
-        [ '20°C'                     , '>'  , QuantityType.new('50°F')   , true  ]  ,
+        [ '10°C'                      , '==' , QuantityType.new('10°C')    , true  ]  ,
+        [ '10°C'                      , '==' , QuantityType.new('50°F')    , true  ]  ,
+        [ '10°C'                      , '==' , QuantityType.new('10°F')    , false ]  ,
+        [ '20°C'                      , '==' , QuantityType.new('10°C')    , false ]  ,
+        [ '10°C'                      , '!=' , QuantityType.new('10°F')    , true  ]  ,
+        [ '10°C'                      , '!=' , QuantityType.new('10.1°C')  , true  ]  ,
+        [ '10°C'                      , '!=' , QuantityType.new('50°F')    , false ]  ,
+        [ '10°C'                      , '!=' , QuantityType.new('10°C')    , false ]  ,
+        [ '10°C'                      , '<'  , QuantityType.new('50°C')    , true  ]  ,
+        [ '10°C'                      , '<'  , QuantityType.new('10°F')    , false ]  ,
+        [ '10°C'                      , '<'  , QuantityType.new('50°F')    , false ]  ,
+        [ '20°C'                      , '>'  , QuantityType.new('10°C')    , true  ]  ,
+        [ '5°C'                       , '>'  , QuantityType.new('10°C')    , false ]  ,
+        [ '20°C'                      , '>'  , QuantityType.new('50°F')    , true  ]  ,
 
         # QuantityType vs Quantity
-        [ QuantityType.new('10°C')   , '==' , Quantity.new('10°C')       , true  ]  ,
-        [ QuantityType.new('50°F')   , '==' , Quantity.new('10°C')       , true  ]  ,
-        [ QuantityType.new('10°F')   , '==' , Quantity.new('10°C')       , false ]  ,
-        [ QuantityType.new('10°C')   , '==' , Quantity.new('20°C')       , false ]  ,
-        [ QuantityType.new('10°F')   , '!=' , Quantity.new('10°C')       , true  ]  ,
-        [ QuantityType.new('10.1°C') , '!=' , Quantity.new('10°C')       , true  ]  ,
-        [ QuantityType.new('50°F')   , '!=' , Quantity.new('10°C')       , false ]  ,
-        [ QuantityType.new('10°C')   , '!=' , Quantity.new('10°C')       , false ]  ,
-        [ QuantityType.new('50°C')   , '>'  , Quantity.new('10°C')       , true  ]  ,
-        [ QuantityType.new('10°F')   , '>'  , Quantity.new('10°C')       , false ]  ,
-        [ QuantityType.new('50°F')   , '>'  , Quantity.new('10°C')       , false ]  ,
-        [ QuantityType.new('10°C')   , '<'  , Quantity.new('20°C')       , true  ]  ,
-        [ QuantityType.new('10°C')   , '<'  , Quantity.new('5°C' )       , false ]  ,
-        [ QuantityType.new('50°F')   , '<'  , Quantity.new('20°C')       , true  ]  ,
+        [ QuantityType.new('10°C')    , '==' , Quantity.new('10°C')        , true  ]  ,
+        [ QuantityType.new('50°F')    , '==' , Quantity.new('10°C')        , true  ]  ,
+        [ QuantityType.new('10°F')    , '==' , Quantity.new('10°C')        , false ]  ,
+        [ QuantityType.new('10°C')    , '==' , Quantity.new('20°C')        , false ]  ,
+        [ QuantityType.new('10°F')    , '!=' , Quantity.new('10°C')        , true  ]  ,
+        [ QuantityType.new('10.1°C')  , '!=' , Quantity.new('10°C')        , true  ]  ,
+        [ QuantityType.new('50°F')    , '!=' , Quantity.new('10°C')        , false ]  ,
+        [ QuantityType.new('10°C')    , '!=' , Quantity.new('10°C')        , false ]  ,
+        [ QuantityType.new('50°C')    , '>'  , Quantity.new('10°C')        , true  ]  ,
+        [ QuantityType.new('10°F')    , '>'  , Quantity.new('10°C')        , false ]  ,
+        [ QuantityType.new('50°F')    , '>'  , Quantity.new('10°C')        , false ]  ,
+        [ QuantityType.new('10°C')    , '<'  , Quantity.new('20°C')        , true  ]  ,
+        [ QuantityType.new('10°C')    , '<'  , Quantity.new('5°C' )        , false ]  ,
+        [ QuantityType.new('50°F')    , '<'  , Quantity.new('20°C')        , true  ]  ,
 
         # Quantity vs QuantityType
-        [ Quantity.new('10°C')       , '==' , QuantityType.new('10°C')   , true  ]  ,
-        [ Quantity.new('10°C')       , '==' , QuantityType.new('50°F')   , true  ]  ,
-        [ Quantity.new('10°C')       , '==' , QuantityType.new('10°F')   , false ]  ,
-        [ Quantity.new('20°C')       , '==' , QuantityType.new('10°C')   , false ]  ,
-        [ Quantity.new('10°C')       , '!=' , QuantityType.new('10°F')   , true  ]  ,
-        [ Quantity.new('10°C')       , '!=' , QuantityType.new('10.1°C') , true  ]  ,
-        [ Quantity.new('10°C')       , '!=' , QuantityType.new('50°F')   , false ]  ,
-        [ Quantity.new('10°C')       , '!=' , QuantityType.new('10°C')   , false ]  ,
-        [ Quantity.new('10°C')       , '<'  , QuantityType.new('50°C')   , true  ]  ,
-        [ Quantity.new('10°C')       , '<'  , QuantityType.new('10°F')   , false ]  ,
-        [ Quantity.new('10°C')       , '<'  , QuantityType.new('50°F')   , false ]  ,
-        [ Quantity.new('20°C')       , '>'  , QuantityType.new('10°C')   , true  ]  ,
-        [ Quantity.new('5°C' )       , '>'  , QuantityType.new('10°C')   , false ]  ,
-        [ Quantity.new('20°C')       , '>'  , QuantityType.new('50°F')   , true  ]  ,
+        [ Quantity.new('10°C')        , '==' , QuantityType.new('10°C')    , true  ]  ,
+        [ Quantity.new('10°C')        , '==' , QuantityType.new('50°F')    , true  ]  ,
+        [ Quantity.new('10°C')        , '==' , QuantityType.new('10°F')    , false ]  ,
+        [ Quantity.new('20°C')        , '==' , QuantityType.new('10°C')    , false ]  ,
+        [ Quantity.new('10°C')        , '!=' , QuantityType.new('10°F')    , true  ]  ,
+        [ Quantity.new('10°C')        , '!=' , QuantityType.new('10.1°C')  , true  ]  ,
+        [ Quantity.new('10°C')        , '!=' , QuantityType.new('50°F')    , false ]  ,
+        [ Quantity.new('10°C')        , '!=' , QuantityType.new('10°C')    , false ]  ,
+        [ Quantity.new('10°C')        , '<'  , QuantityType.new('50°C')    , true  ]  ,
+        [ Quantity.new('10°C')        , '<'  , QuantityType.new('10°F')    , false ]  ,
+        [ Quantity.new('10°C')        , '<'  , QuantityType.new('50°F')    , false ]  ,
+        [ Quantity.new('20°C')        , '>'  , QuantityType.new('10°C')    , true  ]  ,
+        [ Quantity.new('5°C' )        , '>'  , QuantityType.new('10°C')    , false ]  ,
+        [ Quantity.new('20°C')        , '>'  , QuantityType.new('50°F')    , true  ]  ,
 
 
         # PercentType vs Ruby Numeric
-        [ PercentType.new(10)        , '==' , 10                         , true  ]  ,
-        [ PercentType.new(10)        , '==' , 1                          , false ]  ,
-        [ PercentType.new(10)        , '!=' , 1                          , true  ]  ,
-        [ PercentType.new(10)        , '!=' , 10                         , false ]  ,
-        [ PercentType.new(10)        , '<'  , 10.1                       , true  ]  ,
-        [ PercentType.new(10)        , '<'  , 5                          , false ]  ,
-        [ PercentType.new(10)        , '>'  , 5                          , true  ]  ,
-        [ PercentType.new(10)        , '>'  , 10.1                       , false ]  ,
+        [ PercentType.new(10)         , '==' , 10                          , true  ]  ,
+        [ PercentType.new(10)         , '==' , 1                           , false ]  ,
+        [ PercentType.new(10)         , '!=' , 1                           , true  ]  ,
+        [ PercentType.new(10)         , '!=' , 10                          , false ]  ,
+        [ PercentType.new(10)         , '<'  , 10.1                        , true  ]  ,
+        [ PercentType.new(10)         , '<'  , 5                           , false ]  ,
+        [ PercentType.new(10)         , '>'  , 5                           , true  ]  ,
+        [ PercentType.new(10)         , '>'  , 10.1                        , false ]  ,
 
         # Ruby Numeric vs PercentType
-        [ 10                         , '==' , PercentType.new(10)        , true  ]  ,
-        [ 10                         , '==' , PercentType.new(5)         , false ]  ,
-        [ 10                         , '!=' , PercentType.new(5)         , true  ]  ,
-        [ 10                         , '!=' , PercentType.new(10)        , false ]  ,
-        [ 10.5                       , '<'  , PercentType.new(20)        , true  ]  ,
-        [ 10                         , '<'  , PercentType.new(5)         , false ]  ,
-        [ 10                         , '>'  , PercentType.new(5)         , true  ]  ,
-        [ 10                         , '>'  , PercentType.new(10)        , false ]  ,
+        [ 10                          , '==' , PercentType.new(10)         , true  ]  ,
+        [ 10                          , '==' , PercentType.new(5)          , false ]  ,
+        [ 10                          , '!=' , PercentType.new(5)          , true  ]  ,
+        [ 10                          , '!=' , PercentType.new(10)         , false ]  ,
+        [ 10.5                        , '<'  , PercentType.new(20)         , true  ]  ,
+        [ 10                          , '<'  , PercentType.new(5)          , false ]  ,
+        [ 10                          , '>'  , PercentType.new(5)          , true  ]  ,
+        [ 10                          , '>'  , PercentType.new(10)         , false ]  ,
 
         # DecimalType vs Ruby Numeric
-        [ DecimalType.new(10)        , '==' , 10                         , true  ]  ,
-        [ DecimalType.new(10)        , '==' , 1                          , false ]  ,
-        [ DecimalType.new(10)        , '!=' , 1                          , true  ]  ,
-        [ DecimalType.new(10)        , '!=' , 10                         , false ]  ,
-        [ DecimalType.new(10)        , '<'  , 10.1                       , true  ]  ,
-        [ DecimalType.new(10)        , '<'  , 5                          , false ]  ,
-        [ DecimalType.new(10)        , '>'  , 5                          , true  ]  ,
-        [ DecimalType.new(10)        , '>'  , 10.1                       , false ]  ,
+        [ DecimalType.new(10)         , '==' , 10                          , true  ]  ,
+        [ DecimalType.new(10)         , '==' , 1                           , false ]  ,
+        [ DecimalType.new(10)         , '!=' , 1                           , true  ]  ,
+        [ DecimalType.new(10)         , '!=' , 10                          , false ]  ,
+        [ DecimalType.new(10)         , '<'  , 10.1                        , true  ]  ,
+        [ DecimalType.new(10)         , '<'  , 5                           , false ]  ,
+        [ DecimalType.new(10)         , '>'  , 5                           , true  ]  ,
+        [ DecimalType.new(10)         , '>'  , 10.1                        , false ]  ,
 
         # Ruby Numeric vs DecimalType
-        [ 10                         , '==' , DecimalType.new(10)        , true  ]  ,
-        [ 10                         , '==' , DecimalType.new(5)         , false ]  ,
-        [ 10                         , '!=' , DecimalType.new(5)         , true  ]  ,
-        [ 10                         , '!=' , DecimalType.new(10)        , false ]  ,
-        [ 10.5                       , '<'  , DecimalType.new(20)        , true  ]  ,
-        [ 10                         , '<'  , DecimalType.new(5)         , false ]  ,
-        [ 10                         , '>'  , DecimalType.new(5)         , true  ]  ,
-        [ 10                         , '>'  , DecimalType.new(10)        , false ]  ,
+        [ 10                          , '==' , DecimalType.new(10)         , true  ]  ,
+        [ 10                          , '==' , DecimalType.new(5)          , false ]  ,
+        [ 10                          , '!=' , DecimalType.new(5)          , true  ]  ,
+        [ 10                          , '!=' , DecimalType.new(10)         , false ]  ,
+        [ 10.5                        , '<'  , DecimalType.new(20)         , true  ]  ,
+        [ 10                          , '<'  , DecimalType.new(5)          , false ]  ,
+        [ 10                          , '>'  , DecimalType.new(5)          , true  ]  ,
+        [ 10                          , '>'  , DecimalType.new(10)         , false ]  ,
+
+        # DateTime
+        [ DateOne                     , '<'  , DateTwo                     , true  ]  ,
+        [ DateOne                     , '<=' , '2021-02-09'                , true  ]  ,
+        [ DateOne                     , '>'  , Time.now                    , false ]  ,
+        [ DateOne                     , '==' , '2021-01-01T00:00:00+00:00' , true  ]  ,
+        [ DateOne                     , '!=' , '2021-01-01T00:00:00+01:00' , true  ]  ,
+
+        [ DateTwo                     , '<'  , DateOne                     , false ]  ,
+        [ '2021-02-09'                , '>=' , DateOne                     , true  ]  ,
+        [ Time.now                    , '>'  , DateOne                     , true  ]  ,
+        [ '2021-01-01T00:00:00+00:00' , '==' , DateOne                     , true  ]  ,
+        [ '2021-01-01T00:00:00+01:00' , '!=' , DateOne                     , true  ]  ,
+
+        # Rollershutters
+        [ ShutterTwo                  , '==' , 50                          , true  ]  ,
+        [ ShutterOne                  , '<'  , 50                          , true  ]  ,
+        [ ShutterOne                  , '>'  , ShutterTwo                  , false ]  ,
+        [ 50                          , '==' , ShutterTwo                  , true  ]  ,
+        [ 50                          , '<'  , ShutterOne                  , false ]  ,
+        [ ShutterTwo                  , '>'  , ShutterOne                  , true  ]  ,
 
         # Groups
-        [ Temperatures               , '<'  , Temperatures.max           , true  ]  ,
-        [ Temperatures               , '>'  , 0                          , true  ]  ,
-        [ Temperatures               , '>'  , '0 °C'                     , true  ]  ,
-        [ Switches                   ,'=='  , ON                         , false ]  ,
-        [ Switches                   ,'=='  , OFF                        , true  ]  ,
-        [ Switches                   ,'=='  , SwitchTwo                  , true  ]  ,
-        [ Switches                   ,'=='  , SwitchOne                  , false ]  ,
-        [ Contacts                   ,'=='  , OPEN                       , true  ]  ,
-        [ Contacts                   ,'=='  , CLOSED                     , false ]  ,
-        [ Dates                      , '<'  , Time.now                   , true  ]  ,
-        [ Dates                      , '>'  , DateOne                    , true  ]  ,
-        [ Dates                      ,'=='  , DateTwo                    , true  ]  ,
-        [ Dates                      ,'=='  , DateOne                    , false ]  ,
-        [ Dates                      ,'=='  , TimeOfDay.noon             , true  ]  ,
-        [ Shutters                   ,'=='  , UP                         , false ]  ,
-        [ Shutters                   ,'=='  , DOWN                       , true  ]  ,
-        [ ShuttersPos                ,'=='  , 50                         , true  ]  ,
-        [ ShuttersPos                , '<'  , 20                         , false ]  ,
+        [ Temperatures                , '<'  , Temperatures.max            , true  ]  ,
+        [ Temperatures                , '>'  , 0                           , true  ]  ,
+        [ Temperatures                , '>'  , '0 °C'                      , true  ]  ,
+        [ Switches                    , '==' , ON                          , false ]  ,
+        [ Switches                    , '==' , OFF                         , true  ]  ,
+        [ Switches                    , '==' , SwitchTwo                   , true  ]  ,
+        [ Switches                    , '==' , SwitchOne                   , false ]  ,
+        [ Contacts                    , '==' , OPEN                        , true  ]  ,
+        [ Contacts                    , '==' , CLOSED                      , false ]  ,
+        [ Dates                       , '<'  , Time.now                    , true  ]  ,
+        [ Dates                       , '>'  , DateOne                     , true  ]  ,
+        [ Dates                       , '==' , DateTwo                     , true  ]  ,
+        [ Dates                       , '==' , DateOne                     , false ]  ,
+        [ Dates                       , '==' , TimeOfDay.noon              , true  ]  ,
+        [ Shutters                    , '==' , UP                          , false ]  ,
+        [ Shutters                    , '==' , DOWN                        , true  ]  ,
+        [ ShuttersPos                 , '==' , 50                          , true  ]  ,
+        [ ShuttersPos                 , '<'  , 20                          , false ]  ,
 
-        [ Temperatures.max           , '<'  , Temperatures               , false ]  ,
-        # [ 0                          , '>'  , Temperatures               , false ]  ,
-        [ '0 °C'                     , '<'  , Temperatures               , true  ]  ,
-        # [ ON                         ,'=='  , Switches                   , false ]  ,
-        # [ OFF                        ,'=='  , Switches                   , true  ]  ,
-        # [ SwitchTwo                  ,'=='  , Switches                   , true  ]  ,
-        # [ SwitchOne                  ,'=='  , Switches                   , false ]  ,
-        # [ OPEN                       ,'=='  , Contacts                   , true  ]  ,
-        # [ CLOSED                     ,'=='  , Contacts                   , false ]  ,
-        # [ Time.now                   , '<'  , Dates                      , false ]  ,
-        # [ DateOne                    , '>'  , Dates                      , false ]  ,
-        # [ DateTwo                    ,'=='  , Dates                      , true  ]  ,
-        # [ DateOne                    ,'=='  , Dates                      , false ]  ,
-        [ TimeOfDay.noon             ,'=='  , Dates                      , true  ]  ,
-        # [ UP                         ,'=='  , Shutters                   , false ]  ,
-        # [ DOWN                       ,'=='  , Shutters                   , true  ]  ,
-        [ 50                         ,'=='  , ShuttersPos                , true  ]  ,
-        [ 20                         , '<'  , ShuttersPos                , true  ]
+        [ Temperatures.max            , '<'  , Temperatures                , false ]  ,
+        [ '0 °C'                      , '<'  , Temperatures                , true  ]  ,
+        [ ON                          , '==' , Switches                    , false ]  ,
+        [ OFF                         , '==' , Switches                    , true  ]  ,
+        [ SwitchTwo                   , '==' , Switches                    , true  ]  ,
+        [ SwitchOne                   , '==' , Switches                    , false ]  ,
+        [ OPEN                        , '==' , Contacts                    , true  ]  ,
+        [ CLOSED                      , '==' , Contacts                    , false ]  ,
+        [ Time.now                    , '<'  , Dates                       , false ]  ,
+        [ DateOne                     , '>'  , Dates                       , false ]  ,
+        [ DateTwo                     , '==' , Dates                       , true  ]  ,
+        [ DateOne                     , '==' , Dates                       , false ]  ,
+        [ TimeOfDay.noon              , '==' , Dates                       , true  ]  ,
+        [ UP                          , '==' , Shutters                    , false ]  ,
+        [ DOWN                        , '==' , Shutters                    , true  ]  ,
+        [ 50                          , '==' , ShuttersPos                 , true  ]  ,
+        [ 20                          , '<'  , ShuttersPos                 , true  ]
 
       ]
 

--- a/features/datetime_item.feature
+++ b/features/datetime_item.feature
@@ -27,21 +27,6 @@ Feature: datetime_item
         | 1970-01-31T08:00:00+0000 | +        | 20.minutes | 1970-01-31T08:20:00.000+0000 |
         | 1970-01-31T08:00:00+0000 | -        | 20.minutes | 1970-01-31T07:40:00.000+0000 |
 
-    Scenario Outline: DateTime Items support comparisons
-      Given code in a rules file
-        """
-        logger.info(DateOne <operator> <operand>)
-        """
-      When I deploy the rules file
-      Then It should log "<result>" within 5 seconds
-      Examples:
-        | operator | operand                     | result |
-        | <        | DateTwo                     | true   |
-        | <=       | '2021-02-09'                | true   |
-        | >        | Time.now                    | false  |
-        | ==       | '1970-01-01T00:00:00+00:00' | true   |
-        | !=       | '1970-01-01T00:00:00+01:00' | true   |
-
     Scenario Outline: Ruby Time methods work
       Given code in a rules file      
         """

--- a/features/rollershutter_item.feature
+++ b/features/rollershutter_item.feature
@@ -52,20 +52,6 @@ Feature: rollershutter_item
       | 50      | stop   | STOP    |
       | 50      | move   | MOVE    |
 
-  Scenario: Comparisons work
-    Given item "RollerOne" state is changed to "50"
-    And item "RollerTwo" state is changed to "0"
-    And code in a rules file
-      """
-      logger.info(RollerOne <operator> <operand>)
-      """
-    When I deploy the rules file
-    Then It should log "<result>" within 5 seconds
-    Examples:
-      | operator | operand   | result |
-      | ==       | 50        | true   |
-      | >        | RollerTwo | true   |
-
   Scenario: up? and down? methods work
     Given item "RollerOne" state is changed to "<initial>"
     And code in a rules file

--- a/features/units_of_measurement.feature
+++ b/features/units_of_measurement.feature
@@ -73,20 +73,6 @@ Feature:  units_of_measurement
     When I deploy the rules file
     Then It should log 'Result is true' within 5 seconds
 
-  Scenario Outline: Comparisons work with dimensioned numbers and strings representing quantities
-    Given code in a rules file
-      """
-        result = <code_line>
-        logger.info("Result is #{result}")
-      """
-    When I deploy the rules file
-    Then It should log 'Result is <result>' within 5 seconds
-    Examples:
-      | code_line          | result |
-      | NumberC > '4 °F'   | true   |
-      | NumberC == '23 °C' | true   |
-
-
   Scenario: Each unit needs to be normalized for all operations when combining operators with comparitors.
     Given code in a rules file
       """

--- a/lib/openhab/dsl/items/datetime_item.rb
+++ b/lib/openhab/dsl/items/datetime_item.rb
@@ -5,6 +5,7 @@ require 'java'
 require 'time'
 require 'openhab/dsl/types/datetime'
 require 'openhab/dsl/items/item_delegate'
+require 'openhab/dsl/items/item_command'
 
 module OpenHAB
   module DSL

--- a/lib/openhab/dsl/monkey_patch/items/contact_item.rb
+++ b/lib/openhab/dsl/monkey_patch/items/contact_item.rb
@@ -36,6 +36,8 @@ module OpenHAB
           #   result from super if not supplied an OpenClosedType
           #
           def ==(other)
+            other = other.get_state_as(OpenClosedType) if other.respond_to?(:get_state_as)
+
             if other.is_a? OpenClosedType
               state? && state == other
             else

--- a/lib/openhab/dsl/monkey_patch/items/switch_item.rb
+++ b/lib/openhab/dsl/monkey_patch/items/switch_item.rb
@@ -56,6 +56,8 @@ module OpenHAB
           #   otherwise result from super
           #
           def ==(other)
+            other = other.get_state_as(OnOffType) if other.respond_to?(:get_state_as)
+
             if other.is_a? OnOffType
               state? && state == other
             else

--- a/lib/openhab/dsl/monkey_patch/ruby/string.rb
+++ b/lib/openhab/dsl/monkey_patch/ruby/string.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'openhab/dsl/types/quantity'
+require 'openhab/dsl/types/datetime'
+require 'openhab/dsl/items/datetime_item'
 
 module OpenHAB
   module DSL
@@ -21,7 +23,8 @@ module OpenHAB
           #
           def ==(other)
             case other
-            when OpenHAB::DSL::Types::Quantity, QuantityType, Java::OrgOpenhabCoreLibraryTypes::StringType
+            when OpenHAB::DSL::Types::Quantity, QuantityType, Java::OrgOpenhabCoreLibraryTypes::StringType,
+              OpenHAB::DSL::Types::DateTime, OpenHAB::DSL::Items::DateTimeItem
               other == self
             else
               super

--- a/lib/openhab/dsl/monkey_patch/types/on_off_type.rb
+++ b/lib/openhab/dsl/monkey_patch/types/on_off_type.rb
@@ -44,6 +44,21 @@ module OpenHAB
             end
             # rubocop:enable Style/CaseLikeIf
           end
+
+          #
+          # Test for equality
+          #
+          # @param [Object] other Other object to compare against
+          #
+          # @return [Boolean] true if self and other can be considered equal, false otherwise
+          #
+          def ==(other)
+            if other.respond_to?(:get_state_as)
+              self == other.get_state_as(OnOffType)
+            else
+              super
+            end
+          end
         end
       end
     end

--- a/lib/openhab/dsl/monkey_patch/types/open_closed_type.rb
+++ b/lib/openhab/dsl/monkey_patch/types/open_closed_type.rb
@@ -33,6 +33,21 @@ module OpenHAB
               super
             end
           end
+
+          #
+          # Test for equality
+          #
+          # @param [Object] other Other object to compare against
+          #
+          # @return [Boolean] true if self and other can be considered equal, false otherwise
+          #
+          def ==(other)
+            if other.respond_to?(:get_state_as)
+              self == other.get_state_as(OpenClosedType)
+            else
+              super
+            end
+          end
         end
       end
     end

--- a/lib/openhab/dsl/monkey_patch/types/up_down_type.rb
+++ b/lib/openhab/dsl/monkey_patch/types/up_down_type.rb
@@ -30,6 +30,21 @@ module OpenHAB
               super
             end
           end
+
+          #
+          # Test for equality
+          #
+          # @param [Object] other Other object to compare against
+          #
+          # @return [Boolean] true if self and other can be considered equal, false otherwise
+          #
+          def ==(other)
+            if other.respond_to?(:get_state_as)
+              self == other.get_state_as(UpDownType)
+            else
+              super
+            end
+          end
         end
       end
     end

--- a/lib/openhab/dsl/types/datetime.rb
+++ b/lib/openhab/dsl/types/datetime.rb
@@ -75,13 +75,13 @@ module OpenHAB
         # @return [Integer] -1, 0 or 1 depending on the outcome
         #
         def <=>(other)
+          if other.respond_to?(:zoned_date_time)
+            return zoned_date_time.to_instant.compare_to(other.zoned_date_time.to_instant)
+          end
+
           case other
-          when DateTime, DateTimeType, DateTimeItem
-            zoned_date_time.to_instant.compare_to(other.zoned_date_time.to_instant)
-          when TimeOfDay::TimeOfDay, TimeOfDay::TimeOfDayRangeElement
-            to_tod <=> other
-          when String
-            self <=> DateTime.parse(DATE_ONLY_REGEX =~ other ? "#{other}'T'00:00:00#{zone}" : other)
+          when TimeOfDay::TimeOfDay, TimeOfDay::TimeOfDayRangeElement then to_tod <=> other
+          when String then self <=> DateTime.parse(DATE_ONLY_REGEX =~ other ? "#{other}'T'00:00:00#{zone}" : other)
           else
             self <=> DateTime.from(other)
           end


### PR DESCRIPTION
Made some additions to make more comparisons work bi-directionally. Also moved some comparison tests into `comparisons.feature` to speed up the test runs a little.

Most notably made Switch and Contact Items comparable to each other.

**Question:** Do we want to support everything bi-directionally, or should we discourage Yoda-syntax such as
```ruby
CLOSED == ContactItem
```

Fixes #205 

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>