### PR TITLE
fix: handle native java exceptions in clean_backtrace

### DIFF
--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -168,3 +168,13 @@ Given('metadata added to {string} in namespace {string}:') do |item, namespace, 
   response = Rest.add_metadata(item: item, namespace: namespace, config: config)
   raise "Response #{response.pretty_inspect} Request #{response.request.pretty_inspect}" unless response.success?
 end
+
+Given('(set )log level (to ){word}') do |level|
+  set_log_level('jsr223.jruby', level)
+  set_log_level('org.openhab.binding.jrubyscripting', level)
+  set_log_level('org.openhab.core.automation', level)
+end
+
+Given('log level for {word} is set to {word}') do |bundle, level|
+  set_log_level(bundle, level)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,4 +21,10 @@ After('@reset_library') do
   start_openhab
 end
 
+After('@log_level_changed') do
+  set_log_level('jsr223.jruby', 'TRACE')
+  set_log_level('org.openhab.binding.jrubyscripting', 'TRACE')
+  set_log_level('org.openhab.core.automation', 'TRACE')
+end
+
 prepare_openhab

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -98,3 +98,7 @@ def delete_items
   end
   wait_until(seconds: 30, msg: 'Items not empty') { Rest.items.length.zero? }
 end
+
+def set_log_level(bundle, level)
+  openhab_client("log:set #{level.upcase} #{bundle}")
+end


### PR DESCRIPTION
Doesn't get as clean as ruby exceptions, but cleans out the jruby stack frames and just leaves the java ones.

Fixes #220 

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>