### PR TITLE
feat(thing): add boolean methods for checking thing's status

### DIFF
--- a/docs/usage/things.md
+++ b/docs/usage/things.md
@@ -25,5 +25,25 @@ things.each { |thing| logger.info("Thing: #{thing.uid}")}
 logger.info("Thing: #{things['astro:sun:home'].uid}")
 ```
 
-For thing objects now additional methods are provided, however the standard [JRuby alternate names and bean convention applies](https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#alternative-names-and-beans-convention), such that `getUID` becomes `uid`.
+## Thing objects
 
+The standard [JRuby alternate names and bean convention applies](https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#alternative-names-and-beans-convention), such that `getUID` becomes `uid`.
+
+Actions are available via thing objects. For more details see [Actions](../misc/actions/)
+
+Thing status is available through `status` method, which returns one of the values from [ThingStatus](https://www.openhab.org/docs/concepts/things.html#thing-status). Boolean methods are available based on this. 
+
+| Method          | Description                                   |
+| --------------- | --------------------------------------------- |
+| `unitialized?`  | Returns true if the status is `UNINITIALIZED` |
+| `initializing?` | Returns true if the status is `INITIALIZING`  |
+| `unknown?`      | Returns true if the status is `UNKNOWN`       |
+| `online?`       | Returns true if the status is `ONLINE`        |
+| `offline?`      | Returns true if the status is `OFFLINE`       |
+| `removing?`     | Returns true if the status is `REMOVING`      |
+| `removed?`      | Returns true if the status is `REMOVED`       |
+
+```ruby
+logger.info("Audiogroup Status: #{things['chromecast:audiogroup:dd9f8622-eee-4eaf-b33f-cdcdcdeee001121']&.status}")
+logger.info("Audiogroup Online? #{things['chromecast:audiogroup:dd9f8622-eee-4eaf-b33f-cdcdcdeee001121']&.online?}")
+```

--- a/features/thing.feature
+++ b/features/thing.feature
@@ -111,3 +111,19 @@ Feature:  thing
     Then if I wait 5 seconds
     And thing "astro:sun:home" is enabled
     Then It should not log 'Thing astro:sun:home status changed to UNINITIALIZED' within 20 seconds
+
+  Scenario Outline: Rule supports boolean thing status methods
+    Given thing "astro:sun:home" is <enable>
+    And if I wait 5 seconds
+    And code in a rules file
+      """
+      logger.info("Thing is <method> #{things['astro:sun:home'].<method>}")
+      """
+    When I deploy the rules file
+    Then It should log 'Thing is <method> <result>' within 20 seconds
+    Examples:
+      | method         | enable   | result |
+      | online?        | enabled  | true   |
+      | online?        | disabled | false  |
+      | uninitialized? | disabled | true   |
+      | uninitialized? | enabled  | false  |

--- a/lib/openhab/dsl/things.rb
+++ b/lib/openhab/dsl/things.rb
@@ -11,6 +11,7 @@ module OpenHAB
     # Support for OpenHAB Things
     #
     module Things
+      java_import Java::OrgOpenhabCoreThing::ThingStatus
       include OpenHAB::Log
 
       #
@@ -23,6 +24,22 @@ module OpenHAB
         def initialize(thing)
           super
           define_action_methods
+        end
+
+        #
+        # Defines boolean thing status methods
+        #   uninitialized?
+        #   initializing?
+        #   unknown?
+        #   online?
+        #   offline?
+        #   removing?
+        #   removed?
+        #
+        # @return [Boolean] true if the thing status matches the name
+        #
+        ThingStatus.constants.each do |thingstatus|
+          define_method("#{thingstatus.to_s.downcase}?") { status == ThingStatus.value_of(thingstatus) }
         end
 
         private


### PR DESCRIPTION
Boolean methods are available based on ThingStatus. 

| Method          | Description                                   |
| --------------- | --------------------------------------------- |
| `unitialized?`  | Returns true if the status is `UNINITIALIZED` |
| `initializing?` | Returns true if the status is `INITIALIZING`  |
| `unknown?`      | Returns true if the status is `UNKNOWN`       |
| `online?`       | Returns true if the status is `ONLINE`        |
| `offline?`      | Returns true if the status is `OFFLINE`       |
| `removing?`     | Returns true if the status is `REMOVING`      |
| `removed?`      | Returns true if the status is `REMOVED`       |

Example:
```ruby
things['uid'].online?
```