### PR TITLE
Add oh_item to decorated items and fix store_states

### DIFF
--- a/lib/openhab/dsl/items/item_delegate.rb
+++ b/lib/openhab/dsl/items/item_delegate.rb
@@ -41,6 +41,7 @@ module OpenHAB
             logger.trace("Creating delegate for (#{method}) to #{item}) for #{self.class}")
             def_delegator item, method
           end
+          define_method(:oh_item) { instance_variable_get(item) }
         end
 
         #

--- a/lib/openhab/dsl/states.rb
+++ b/lib/openhab/dsl/states.rb
@@ -48,7 +48,8 @@ module OpenHAB
       # @return [StateStorage] item states
       #
       def store_states(*items)
-        states = StateStorage.new(BusEvent.storeStates(*items.flatten).to_h)
+        items = items.flatten.map { |item| item.respond_to?(:oh_item) ? item.oh_item : item }
+        states = StateStorage.new(BusEvent.storeStates(*items).to_h)
         if block_given?
           yield
           states.restore


### PR DESCRIPTION
This PR contains two separate commits, which when combined, will resolve #241

The first commit adds oh_item method to decorated items through def_item_delegator, so that all decorated item classes will have oh_item method that returns the underlying openhab object.

This in turn is utilised by the second commit to fix the problem with store_states.