### PR TITLE
refactor: rename the openhab item to oh_item in the wrappers

### DIFF
--- a/lib/openhab/dsl/items/datetime_item.rb
+++ b/lib/openhab/dsl/items/datetime_item.rb
@@ -21,7 +21,8 @@ module OpenHAB
         extend OpenHAB::DSL::Items::ItemCommand
         include Comparable
 
-        def_item_delegator :@datetime_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         item_type Java::OrgOpenhabCoreLibraryItems::DateTimeItem
 
@@ -32,8 +33,8 @@ module OpenHAB
         # delegate to
         #
         def initialize(datetime_item)
-          @datetime_item = datetime_item
-          item_missing_delegate { @datetime_item }
+          @oh_item = datetime_item
+          item_missing_delegate { @oh_item }
           item_missing_delegate { to_dt }
         end
 
@@ -43,7 +44,7 @@ module OpenHAB
         # @return [OpenHAB::DSL::Types::DateTime] Wrapper for the Item's state, or nil if it has no state
         #
         def to_dt
-          OpenHAB::DSL::Types::DateTime.new(@datetime_item.state) if state?
+          OpenHAB::DSL::Types::DateTime.new(@oh_item.state) if state?
         end
 
         #

--- a/lib/openhab/dsl/items/group_item.rb
+++ b/lib/openhab/dsl/items/group_item.rb
@@ -36,7 +36,8 @@ module OpenHAB
         include Enumerable
         include Comparable
 
-        def_item_delegator :@group_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         #
         # @return [Hash] A hash of lambdas with default filters for `all_members`
@@ -54,9 +55,9 @@ module OpenHAB
         # @param [Java::Org::openhab::core::items::GroupItem] group_item OpenHAB GroupItem to delegate to
         #
         def initialize(group_item)
-          @group_item = group_item
+          @oh_item = group_item
 
-          item_missing_delegate { @group_item }
+          item_missing_delegate { @oh_item }
           item_missing_delegate { OpenHAB::Core::EntityLookup.decorate_item(base_item) }
         end
 
@@ -66,14 +67,14 @@ module OpenHAB
         # @return [GroupMembers] A GroupMembers object
         #
         def members
-          GroupMembers.new(@group_item)
+          GroupMembers.new(@oh_item)
         end
 
         #
         # Iterates through the direct members of the Group
         #
         def each(&block)
-          OpenHAB::Core::EntityLookup.decorate_items(@group_item.members.to_a).each(&block)
+          OpenHAB::Core::EntityLookup.decorate_items(@oh_item.members.to_a).each(&block)
         end
 
         #
@@ -87,9 +88,9 @@ module OpenHAB
         def all_members(filter = nil, &block)
           predicate = DEFAULT_FILTERS[filter] || block
 
-          return OpenHAB::Core::EntityLookup.decorate_items(@group_item.all_members.to_a) unless predicate
+          return OpenHAB::Core::EntityLookup.decorate_items(@oh_item.all_members.to_a) unless predicate
 
-          OpenHAB::Core::EntityLookup.decorate_items(@group_item.get_members(&predicate).to_a)
+          OpenHAB::Core::EntityLookup.decorate_items(@oh_item.get_members(&predicate).to_a)
         end
 
         #

--- a/lib/openhab/dsl/items/image_item.rb
+++ b/lib/openhab/dsl/items/image_item.rb
@@ -18,7 +18,8 @@ module OpenHAB
         extend OpenHAB::DSL::Items::ItemCommand
         extend OpenHAB::DSL::Items::ItemDelegate
 
-        def_item_delegator :@image_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         item_type Java::OrgOpenhabCoreLibraryItems::ImageItem
 
@@ -30,9 +31,9 @@ module OpenHAB
         #
         def initialize(image_item)
           logger.trace("Wrapping #{image_item}")
-          @image_item = image_item
+          @oh_item = image_item
 
-          item_missing_delegate { @image_item }
+          item_missing_delegate { @oh_item }
 
           super()
         end
@@ -46,7 +47,7 @@ module OpenHAB
         #
         def update(base_64_encoded_image)
           logger.trace { "Updating #{self} with Base64 image #{base_64_encoded_image}" }
-          @image_item.update base_64_encoded_image
+          @oh_item.update base_64_encoded_image
         end
 
         #

--- a/lib/openhab/dsl/items/number_item.rb
+++ b/lib/openhab/dsl/items/number_item.rb
@@ -19,7 +19,8 @@ module OpenHAB
         extend OpenHAB::DSL::Items::ItemDelegate
         extend OpenHAB::DSL::Items::ItemCommand
 
-        def_item_delegator :@number_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         java_import org.openhab.core.library.types.DecimalType
         java_import org.openhab.core.library.types.QuantityType
@@ -34,8 +35,8 @@ module OpenHAB
         # @param [Java::Org::openhab::core::library::items::NumberItem] number_item OpenHAB number item to delegate to
         #
         def initialize(number_item)
-          @number_item = number_item
-          item_missing_delegate { @number_item }
+          @oh_item = number_item
+          item_missing_delegate { @oh_item }
           super()
         end
 
@@ -45,7 +46,7 @@ module OpenHAB
         # @return [Boolean] True if item is not in state UNDEF or NULL and value is not zero.
         #
         def truthy?
-          @number_item.state? && @number_item.state != DecimalType::ZERO
+          @oh_item.state? && @oh_item.state != DecimalType::ZERO
         end
 
         #
@@ -109,7 +110,7 @@ module OpenHAB
         #
         def to_qt
           if dimension
-            Quantity.new(@number_item.get_state_as(QuantityType))
+            Quantity.new(@oh_item.get_state_as(QuantityType))
           else
             Quantity.new(QuantityType.new(to_d.to_java, AbstractUnit::ONE))
           end
@@ -139,7 +140,7 @@ module OpenHAB
         # @return [BigDecimal] NumberItem as a BigDecimal
         #
         def to_d
-          @number_item.state.to_big_decimal.to_d if @number_item.state.respond_to? :to_big_decimal
+          @oh_item.state.to_big_decimal.to_d if @oh_item.state.respond_to? :to_big_decimal
         end
 
         #
@@ -148,7 +149,7 @@ module OpenHAB
         # @return [Java::org::openhab::core::library::types::QuantityType] dimension
         #
         def dimension
-          @number_item.dimension
+          @oh_item.dimension
         end
 
         %w[+ - * /].each do |operation|
@@ -170,7 +171,7 @@ module OpenHAB
         #
         def state_compare(other)
           other = other.state if other.respond_to? :state
-          @number_item.state <=> other
+          @oh_item.state <=> other
         end
 
         #
@@ -182,7 +183,7 @@ module OpenHAB
         #   nil if this number item does not have a dimension
         #
         def string_compare(other)
-          @number_item.state <=> QuantityType.new(other) if dimension
+          @oh_item.state <=> QuantityType.new(other) if dimension
         end
 
         #
@@ -193,7 +194,7 @@ module OpenHAB
         # @return [Integer] -1,0,1 depending on less than, equal to or greater than other
         #
         def numeric_compare(other)
-          @number_item.state.to_big_decimal.to_d <=> other.to_d
+          @oh_item.state.to_big_decimal.to_d <=> other.to_d
         end
 
         #
@@ -284,7 +285,7 @@ module OpenHAB
             logger.trace('Other is dimensioned, converting self and other to QuantityTypes to compare')
             to_qt <=> other.to_qt
           else
-            @number_item.state <=> other.state
+            @oh_item.state <=> other.state
           end
         end
 
@@ -299,8 +300,8 @@ module OpenHAB
         def coerce_from_numeric(other)
           if dimension
             [Quantity.new(other), to_qt]
-          elsif @number_item.state?
-            [other.to_d, @number_item.state.to_big_decimal.to_d]
+          elsif @oh_item.state?
+            [other.to_d, @oh_item.state.to_big_decimal.to_d]
           end
         end
 

--- a/lib/openhab/dsl/items/player_item.rb
+++ b/lib/openhab/dsl/items/player_item.rb
@@ -16,7 +16,8 @@ module OpenHAB
         extend OpenHAB::DSL::Items::ItemDelegate
         extend Forwardable
 
-        def_item_delegator :@player_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         item_type Java::OrgOpenhabCoreLibraryItems::PlayerItem, :play? => :playing?,
                                                                 :pause? => :paused?,
@@ -37,9 +38,9 @@ module OpenHAB
         #
         def initialize(player_item)
           logger.trace("Wrapping #{player_item}")
-          @player_item = player_item
+          @oh_item = player_item
 
-          item_missing_delegate { @player_item }
+          item_missing_delegate { @oh_item }
 
           super()
         end

--- a/lib/openhab/dsl/items/rollershutter_item.rb
+++ b/lib/openhab/dsl/items/rollershutter_item.rb
@@ -17,7 +17,8 @@ module OpenHAB
         extend OpenHAB::DSL::Items::ItemDelegate
         include Comparable
 
-        def_item_delegator :@rollershutter_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         item_type Java::OrgOpenhabCoreLibraryItems::RollershutterItem
 
@@ -29,9 +30,9 @@ module OpenHAB
         #
         def initialize(rollershutter_item)
           logger.trace("Wrapping #{rollershutter_item}")
-          @rollershutter_item = rollershutter_item
+          @oh_item = rollershutter_item
 
-          item_missing_delegate { @rollershutter_item }
+          item_missing_delegate { @oh_item }
           item_missing_delegate { position }
 
           super()

--- a/lib/openhab/dsl/items/string_item.rb
+++ b/lib/openhab/dsl/items/string_item.rb
@@ -21,7 +21,8 @@ module OpenHAB
         BLANK_RE = /\A[[:space:]]*\z/.freeze
         private_constant :BLANK_RE
 
-        def_item_delegator :@string_item
+        def_item_delegator :@oh_item
+        attr_reader :oh_item
 
         item_type Java::OrgOpenhabCoreLibraryItems::StringItem
 
@@ -31,10 +32,10 @@ module OpenHAB
         # @param [Java::Org::openhab::core::library::items::StringItem] string_item OpenHAB string item to delegate to
         #
         def initialize(string_item)
-          @string_item = string_item
+          @oh_item = string_item
 
-          item_missing_delegate { @string_item }
-          item_missing_delegate { @string_item.state&.to_full_string&.to_s }
+          item_missing_delegate { @oh_item }
+          item_missing_delegate { @oh_item.state&.to_full_string&.to_s }
 
           super()
         end
@@ -46,7 +47,7 @@ module OpenHAB
         #   nil if underlying OpenHAB StringItem does not have a state
         #
         def to_str
-          @string_item.state&.to_full_string&.to_s
+          @oh_item.state&.to_full_string&.to_s
         end
 
         #
@@ -55,9 +56,9 @@ module OpenHAB
         # @return [Boolean] True if string item is not set or contains only whitespace, false otherwise
         #
         def blank?
-          return true unless @string_item.state?
+          return true unless @oh_item.state?
 
-          @string_item.state.to_full_string.to_s.empty? || BLANK_RE.match?(self)
+          @oh_item.state.to_full_string.to_s.empty? || BLANK_RE.match?(self)
         end
 
         #
@@ -66,7 +67,7 @@ module OpenHAB
         # @return [Boolean] True if item is not in state UNDEF or NULL and value is not blank
         #
         def truthy?
-          @string_item.state? && blank? == false
+          @oh_item.state? && blank? == false
         end
 
         #
@@ -80,11 +81,11 @@ module OpenHAB
         def <=>(other)
           case other
           when StringItem
-            @string_item.state <=> other.state
+            @oh_item.state <=> other.state
           when String
-            @string_item.state.to_s <=> other
+            @oh_item.state.to_s <=> other
           else
-            @string_item.state <=> other
+            @oh_item.state <=> other
           end
         end
       end


### PR DESCRIPTION
An alternative to #242. If you know of a better way, feel free to discard this PR