### PR TITLE
fix(items): format BigDecimal state as a string the parser accepts

### DIFF
--- a/lib/openhab/dsl/monkey_patch/items/items.rb
+++ b/lib/openhab/dsl/monkey_patch/items/items.rb
@@ -47,6 +47,7 @@ module OpenHAB
           #
           #
           def update(update)
+            update = update.to_java.strip_trailing_zeros.to_plain_string if update.is_a? BigDecimal
             logger.trace "Sending Update #{update} to #{id}"
             BusEvent.postUpdate(self, update.to_s)
           end


### PR DESCRIPTION
OH 3.1.0.M5 changed the string parser for Number Items, so it no longer accepts the format output by BigDecimal.to_s. This fix calls `to_java.to_plain_string` on all BigDecimal values before they're sent to the event bus, so they can be parsed correctly.

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>