### PR TITLE
fix(items): decorated items could not be used as hash keys

### DIFF
--- a/features/items.feature
+++ b/features/items.feature
@@ -238,3 +238,25 @@ Feature:  items
       """
     When I deploy the rules file
     Then It should not log "missing oh_item for DSL GroupItem" within 5 seconds
+
+  Scenario Outline: Items can be used as hash keys
+    # Ref: https://github.com/boc-tothefuture/openhab-jruby/issues/252
+    Given items:
+      | type   | name   |
+      | <type> | <name> |
+    And code in a rules file
+      """
+      ITEMS_HASH = { <name> => "I'm <name>" }
+      logger.info("#{ITEMS_HASH[<name>]}")
+      logger.info("<name>.hash == <name>.hash: #{<name>.hash == <name>.hash}")
+      logger.info("<name>.eql?(<name>): #{<name>.eql?(<name>)}")
+      """
+    When I deploy the rules file
+    Then It should log "I'm <name>" within 5 seconds
+    And It should log "<name>.hash == <name>.hash: true" within 5 seconds
+    And It should log "<name>.eql?(<name>): true" within 5 seconds
+    Examples:
+      | type   | name    |
+      | Number | Number1 |
+      | String | String1 |
+      | Player | Player1 |

--- a/lib/openhab/dsl/items/item_delegate.rb
+++ b/lib/openhab/dsl/items/item_delegate.rb
@@ -42,6 +42,8 @@ module OpenHAB
             def_delegator item, method
           end
           define_method(:oh_item) { instance_variable_get(item) }
+          define_method(:hash) { oh_item.hash_code }
+          define_method(:eql?) { |other| hash == other.hash }
         end
 
         #


### PR DESCRIPTION
Resolve #252 by delegating decorated items' #hash to GenericItem.hashCode() as suggested by @pacive in https://github.com/boc-tothefuture/openhab-jruby/pull/253#issuecomment-853558929 