### PR TITLE
feat(duration): support duration methods on Float too

### DIFF
--- a/docs/usage/misc/duration.md
+++ b/docs/usage/misc/duration.md
@@ -8,7 +8,13 @@ grand_parent: Usage
 ---
 
 # Duration
-[Ruby integers](https://ruby-doc.org/core-2.5.0/Integer.html) are extended with several methods to support durations. These methods create a new [java.time.Duration](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html) object that is used by the [Every trigger](../../triggers/every/), [delay](../../execution/delay/), the [for option](../../triggers/changed/) and [timers](../../misc/timers/). 
+Ruby [integers](https://ruby-doc.org/core-2.5.0/Integer.html) and
+[floats](https://ruby-doc.org/core-2.5.0/Float.html) are extended with several
+methods to support durations. These methods create a new
+[java.time.Duration](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html)
+object that is used by the [Every trigger](../../triggers/every/),
+[delay](../../execution/delay/), the [for option](../../triggers/changed/) and
+[timers](../../misc/timers/). 
 
 ## Extended Methods
 

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -16,6 +16,18 @@ Feature:  timer
     But if I wait 2 seconds
     Then It should log 'Timer Fired' within 5 seconds
 
+  Scenario: Timers support non-integral durations
+    Given code in a rules file
+      """
+      after 2.5.seconds do
+        logger.info("Timer Fired")
+      end
+      """
+    When I deploy the rules file
+    Then It should not log 'Timer Fired' within 1 seconds
+    But if I wait 3 seconds
+    Then It should log 'Timer Fired' within 5 seconds
+
   Scenario: Timers support 'active?', 'running?' and 'terminated?'
     Given code in a rules file
       """

--- a/lib/openhab/dsl/monkey_patch/ruby/number.rb
+++ b/lib/openhab/dsl/monkey_patch/ruby/number.rb
@@ -26,14 +26,58 @@ module OpenHAB
           alias minute minutes
           alias hour hours
         end
+
+        #
+        # Extend float to create duration object
+        #
+        module FloatExtensions
+          #
+          # Create Duration with number of milliseconds
+          #
+          # @return [Java::JavaTime::Duration] Duration truncated to an integral number of milliseconds from self
+          #
+          def millis
+            Java::JavaTime::Duration.of_millis(to_i)
+          end
+
+          #
+          # Create Duration with number of seconds
+          #
+          # @return [Java::JavaTime::Duration] Duration with number of seconds from self
+          #
+          def seconds
+            (self * 1000).millis
+          end
+
+          #
+          # Create Duration with number of minutes
+          #
+          # @return [Java::JavaTime::Duration] Duration with number of minutes from self
+          #
+          def minutes
+            (self * 60).seconds
+          end
+
+          #
+          # Create Duration with number of hours
+          #
+          # @return [Java::JavaTime::Duration] Duration with number of hours from self
+          #
+          def hours
+            (self * 60).minutes
+          end
+
+          alias second seconds
+          alias millisecond millis
+          alias milliseconds millis
+          alias ms millis
+          alias minute minutes
+          alias hour hours
+        end
       end
     end
   end
 end
 
-#
-# Prepend Integer class with duration extensions
-#
-class Integer
-  prepend OpenHAB::DSL::MonkeyPatch::Ruby::IntegerExtensions
-end
+Integer.prepend(OpenHAB::DSL::MonkeyPatch::Ruby::IntegerExtensions)
+Float.prepend(OpenHAB::DSL::MonkeyPatch::Ruby::FloatExtensions)


### PR DESCRIPTION
closes #263

have to actually do math to not lose precision finer than 1ms,
and then truncate to integer once we're at ms