### PR TITLE
fix(dev): ignore lockfile for file named gems.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /docs/yard/
 /coverage/
 /doc/
+/lib/openhab/dsl/gems.locked
 /pkg/
 /spec/reports/
 /tmp/


### PR DESCRIPTION
bundler supports gems.rb as an alternate name for Gemfile. I haven't
tracked down exactly when bundler tries to run for gems.rb as the
Gemfile, but it keeps poppig up in my local repo