### PR TITLE
fix(things, items): avoid wrapping every OpenHAB object

### DIFF
--- a/lib/openhab/dsl/items/group_item.rb
+++ b/lib/openhab/dsl/items/group_item.rb
@@ -13,7 +13,9 @@ module OpenHAB
       #
       # Class for indicating to triggers that a group trigger should be used
       #
-      class GroupMembers < SimpleDelegator
+      class GroupMembers
+        include Enumerable
+
         attr_reader :group
 
         #
@@ -23,8 +25,24 @@ module OpenHAB
         #
         def initialize(group_item)
           @group = group_item
-          super(OpenHAB::Core::EntityLookup.decorate_items(@group.members.to_a))
         end
+
+        # Calls the given block once for each group member, passing that
+        # item as a parameter. Returns self.
+        #
+        # If no block is given, an Enumerator is returned.
+        def each(&block)
+          to_a.each(&block)
+          self
+        end
+
+        # explicit conversion to array
+        # more efficient than letting Enumerable do it
+        def to_a
+          OpenHAB::Core::EntityLookup.decorate_items(group.members.to_a)
+        end
+        # implicitly convertible to array
+        alias to_ary to_a
       end
 
       #
@@ -73,7 +91,7 @@ module OpenHAB
         # Iterates through the direct members of the Group
         #
         def each(&block)
-          OpenHAB::Core::EntityLookup.decorate_items(@group_item.members.to_a).each(&block)
+          members.each(&block)
         end
 
         #

--- a/lib/openhab/dsl/items/items.rb
+++ b/lib/openhab/dsl/items/items.rb
@@ -2,6 +2,7 @@
 
 require 'java'
 require 'openhab/core/entity_lookup'
+require 'singleton'
 
 module OpenHAB
   module DSL
@@ -12,11 +13,14 @@ module OpenHAB
       #
       # Delegates to underlying set of all OpenHAB Items, provides convenience methods
       #
-      class Items < SimpleDelegator
+      class Items
+        include Enumerable
+        include Singleton
+
         # Fetches the named item from the the ItemRegistry
         # @param [String] name
         # @return Item from registry, nil if item missing or requested item is a Group Type
-        def[](name)
+        def [](name)
           OpenHAB::Core::EntityLookup.lookup_item(name)
         rescue Java::OrgOpenhabCoreItems::ItemNotFoundException
           nil
@@ -26,19 +30,35 @@ module OpenHAB
         # @param name [String] Item name to check
         # @return [Boolean] true if the item exists, false otherwise
         def include?(name)
-          # rubocop: disable Style/GlobalVars
-          !$ir.getItems(name).empty?
-          # rubocop: enable Style/GlobalVars
+          !$ir.getItems(name).empty? # rubocop: disable Style/GlobalVars
         end
         alias key? include?
+
+        # Calls the given block once for each Item, passing that Item as a
+        # parameter. Returns self.
+        #
+        # If no block is given, an Enumerator is returned.
+        def each(&block)
+          # ideally we would do this lazily, but until ruby 2.7
+          # there's no #eager method to convert back to a non-lazy
+          # enumerator
+          to_a.each(&block)
+        end
+
+        # explicit conversion to array
+        # more efficient than letting Enumerable do it
+        def to_a
+          items = $ir.items.grep_v(Java::OrgOpenhabCoreItems::GroupItem) # rubocop:disable Style/GlobalVars
+          OpenHAB::Core::EntityLookup.decorate_items(items)
+        end
+        # implicitly convertible to array
+        alias to_ary to_a
       end
 
       # Fetches all non-group items from the item registry
       # @return [OpenHAB::DSL::Items::Items]
       def items
-        # rubocop: disable Style/GlobalVars
-        Items.new(OpenHAB::Core::EntityLookup.decorate_items($ir.items.grep_v(Java::OrgOpenhabCoreItems::GroupItem)))
-        # rubocop: enable Style/GlobalVars
+        Items.instance
       end
     end
   end

--- a/lib/openhab/dsl/rules/triggers/command.rb
+++ b/lib/openhab/dsl/rules/triggers/command.rb
@@ -22,7 +22,7 @@ module OpenHAB
         #
         #
         def received_command(*items, command: nil, commands: nil)
-          separate_groups(items).flatten.each do |item|
+          separate_groups(items).each do |item|
             logger.trace("Creating received command trigger for item(#{item})"\
                          "command(#{command}) commands(#{commands})")
 

--- a/lib/openhab/dsl/rules/triggers/trigger.rb
+++ b/lib/openhab/dsl/rules/triggers/trigger.rb
@@ -61,9 +61,13 @@ module OpenHAB
         # @return [Array] A new flat array with any GroupMembers object left intact
         #
         def separate_groups(item_array)
-          return item_array if item_array.grep(Array).length.zero?
+          # we want to support anything that can be flattened... i.e. responds to to_ary
+          # we want to be more lenient than only things that are currently Array,
+          # but Enumerable is too lenient because Array#flatten won't traverse interior
+          # Enumerables
+          return item_array unless item_array.find { |item| item.respond_to?(:to_ary) }
 
-          groups, items = item_array.partition { |item| item.is_a? OpenHAB::DSL::Items::GroupItem::GroupMembers }
+          groups, items = item_array.partition { |item| item.is_a?(OpenHAB::DSL::Items::GroupItem::GroupMembers) }
           groups + separate_groups(items.flatten(1))
         end
 

--- a/lib/openhab/dsl/rules/triggers/updated.rb
+++ b/lib/openhab/dsl/rules/triggers/updated.rb
@@ -20,7 +20,7 @@ module OpenHAB
         # @return [Trigger] Trigger for updated entity
         #
         def updated(*items, to: nil)
-          separate_groups(items).flatten.each do |item|
+          separate_groups(items).each do |item|
             logger.trace("Creating updated trigger for item(#{item}) to(#{to})")
             [to].flatten.each do |to_state|
               trigger, config = create_update_trigger(item, to_state)


### PR DESCRIPTION
a common use case is to use `items[dynamic_item_name]` or
`things[dynamic_thing_name]` to get a non-constant item or thing.
the old code would instantiate a new array or set of all items/things
in OpenHAB, and then immediately discard it when the [] method is used
to look up the item individually. this change delays instantiating
until an actual enumerable method is used