### PR TITLE
feat(group_item): alias items to members

### DIFF
--- a/features/received_command.feature
+++ b/features/received_command.feature
@@ -66,7 +66,7 @@ Feature:  received_command
     Given a deployed rule:
       """
       rule 'Execute rule when member of group receives any command' do
-        received_command AlarmModes.items
+        received_command AlarmModes.members
         triggered { |item| logger.info("Group item #{item.id} received command")}
       end
       """
@@ -77,7 +77,7 @@ Feature:  received_command
     Given a deployed rule:
       """
       rule 'Execute rule when member of group is changed to one of many states' do
-        received_command AlarmModes.items, commands: [7,14]
+        received_command AlarmModes.members, commands: [7,14]
         triggered { |item| logger.info("Group item #{item.id} received command")}
       end
       """

--- a/lib/openhab/dsl/items/group_item.rb
+++ b/lib/openhab/dsl/items/group_item.rb
@@ -68,6 +68,7 @@ module OpenHAB
         def members
           GroupMembers.new(@group_item)
         end
+        alias items members
 
         #
         # Iterates through the direct members of the Group


### PR DESCRIPTION
while #members is the documented method, this reduces confusion because
the "global" Items#items is being leaked onto this object. so this hides
the global, and makes it behave as you expect