### PR TITLE
fix(dev): update gemfile and binstubs for use with MRI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
     nenv (0.3.0)
     nokogiri (1.12.4-java)
       racc (~> 1.4)
+    nokogiri (1.12.4-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.4-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -229,6 +231,7 @@ GEM
 
 PLATFORMS
   universal-java-11
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,4 +1,4 @@
-#!/usr/bin/env jruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 #

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/env jruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 #

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,4 +1,4 @@
-#!/usr/bin/env jruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 #


### PR DESCRIPTION
they'll still work with JRuby, but github actions runs with MRI, and it's
nice to use MRI locally for development type stuff because it's faster
to boot up.