### PR TITLE
feat(attachments): adds attachments to triggers

### DIFF
--- a/docs/usage/execution/run.md
+++ b/docs/usage/execution/run.md
@@ -25,39 +25,42 @@ The following properties exist when a run block is triggered from an [updated](#
 | was?       | Prior state of triggering item was not NULL or UNDEF   |
 | was_null?  | Prior state was NULL                                   |
 | was_undef? | Prior state was UNDEF                                  |
+| attachment | Optional user provided attachment to trigger           |
 
 For compatibility, `last` is also aliased to `was`.
 
 ## Command Event Properties
 The following properties exist when a run block is triggered from a [received_command](#received_command) trigger.
 
-| Property     | Description                   |
-| ------------ | ----------------------------- |
-| command      | Command sent to item          |
-| refresh?     | If the command is REFRESH     |
-| on?          | If the command is ON          |
-| off?         | If the command is OFF         |
-| increase?    | If the command is INCREASE    |
-| decrease?    | If the command is DECREASE    |
-| up?          | If the command is UP          |
-| down?        | If the command is DOWN        |
-| stop?        | If the command is STOP        |
-| move?        | If the command is MOVE        |
-| play?        | If the command is PLAY        |
-| pause?       | If the command is PAUSE       |
-| rewind?      | If the command is REWIND      |
-| fastforward? | If the command is FASTFORWARD |
-| next?        | If the command is NEXT        |
-| previous?    | If the command is PREVIOUS    |
+| Property     | Description                                  |
+|--------------|----------------------------------------------|
+| command      | Command sent to item                         |
+| refresh?     | If the command is REFRESH                    |
+| on?          | If the command is ON                         |
+| off?         | If the command is OFF                        |
+| increase?    | If the command is INCREASE                   |
+| decrease?    | If the command is DECREASE                   |
+| up?          | If the command is UP                         |
+| down?        | If the command is DOWN                       |
+| stop?        | If the command is STOP                       |
+| move?        | If the command is MOVE                       |
+| play?        | If the command is PLAY                       |
+| pause?       | If the command is PAUSE                      |
+| rewind?      | If the command is REWIND                     |
+| fastforward? | If the command is FASTFORWARD                |
+| next?        | If the command is NEXT                       |
+| previous?    | If the command is PREVIOUS                   |
+| attachment   | Optional user provided attachment to trigger |
 
 ## Thing Event Properties
 The following properties exist when a run block is triggered from an  [updated](#updated) or [changed](#changed) trigger on a Thing.
 
-| Property | Description                                                       |
-| -------- | ----------------------------------------------------------------- |
-| uid      | UID of the triggered Thing                                        |
-| last     | Status before Change for thing (only valid on Change, not update) |
-| status   | Current status of the triggered Thing                             |
+| Property   | Description                                                       |
+|------------|-------------------------------------------------------------------|
+| uid        | UID of the triggered Thing                                        |
+| last       | Status before Change for thing (only valid on Change, not update) |
+| status     | Current status of the triggered Thing                             |
+| attachment | Optional user provided attachment to trigger                      |
 
 
 

--- a/docs/usage/triggers.md
+++ b/docs/usage/triggers.md
@@ -6,3 +6,25 @@ has_children: true
 parent: Usage
 ---
 
+# Trigger Attachments
+
+All triggers except cron based triggers (every, cron) support event attachments that enable the association of an object to a trigger.
+
+| Method | Description                   | example                       |
+|--------|-------------------------------|-------------------------------|
+| attach | attach an object to a trigger | changed Switch, attach: 'foo' |
+
+This enables one to use the same rule and take different actions if the trigger is different. 
+
+The attached object is then available on the event object with by the 'attachment' accessor.
+
+## Example
+
+```ruby
+rule 'Set Dark switch at sunrise and sunset' do
+  channel 'astro:sun:home:rise#event', attach: OFF
+  channel 'astro:sun:home:set#event', attach: ON
+  run { |event| Dark << event.attachment }
+end
+```
+

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -1,0 +1,26 @@
+Feature:  attachments
+  Rule languages supports attachements on triggers
+
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
+
+  Scenario Outline: Triggers works with attachments
+    Given items:
+      | type   | name    | label             | state | 
+      | Switch | Switch1 | Switch Number One | OFF   | 
+    And a deployed rule:
+      """
+      rule 'Access attachment' do
+        <trigger>, attach: '<attachment>'
+        run { |event| logger.info("attachment - #{event.attachment}")}
+      end
+      """
+    When <action>
+    Then It should log 'attachment - <attachment>' within 5 seconds
+    Examples: Checks multiple attachments
+      | trigger                                 | attachment | action                                                   |
+      | changed Switch1                         | foo        | item "Switch1" state is changed to "ON"                  |
+      | received_command Switch1                | baz        | item "Switch1" state is changed to "ON"                  |
+      | updated Switch1                         | bar        | item "Switch1" state is changed to "ON"                  |
+      | channel 'astro:sun:home:rise#event'     | quz        | channel "astro:sun:home:rise#event " is triggered        |
+      | on_start true                           | qaz        | I wait 2 seconds                                         |

--- a/features/step_definitions/support.rb
+++ b/features/step_definitions/support.rb
@@ -5,11 +5,11 @@
 require 'fileutils'
 require 'tmpdir'
 
-Then('If I wait {int} seconds') do |int|
+Then('If I wait {int} second(s)') do |int|
   sleep(int)
 end
 
-When('(if )I wait {int} seconds') do |int|
+When('(if )I wait {int} second(s)') do |int|
   sleep(int)
 end
 

--- a/lib/openhab/dsl/rules/item_event.rb
+++ b/lib/openhab/dsl/rules/item_event.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module DSL
+    module Rules
+      #
+      # Extends OpenHAB events
+      #
+      module Events
+        java_import org.openhab.core.events.AbstractEvent
+
+        # Add attachments to ItemEvent
+        class AbstractEvent
+          attr_accessor :attachment
+        end
+      end
+    end
+  end
+end

--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -87,7 +87,7 @@ module OpenHAB
         rule = AutomationRule.new(config: config)
         Rules.script_rules << rule
         add_rule(rule)
-        rule.execute if config.on_start?
+        rule.execute(nil, { 'event' => Struct.new(:attachment).new(config.start_attachment) }) if config.on_start?
       end
 
       #

--- a/lib/openhab/dsl/rules/rule_config.rb
+++ b/lib/openhab/dsl/rules/rule_config.rb
@@ -37,6 +37,9 @@ module OpenHAB
         # @return [Array] Of trigger delays
         attr_reader :trigger_delays
 
+        # @return [Hash] Hash of trigger UIDs to attachments
+        attr_reader :attachments
+
         # @return [Array] Of trigger guards
         attr_accessor :guard
 
@@ -82,6 +85,7 @@ module OpenHAB
         def initialize(rule_name, caller_binding)
           @triggers = []
           @trigger_delays = {}
+          @attachments = {}
           @caller = caller_binding.eval 'self'
           enabled(true)
           on_start(false)
@@ -96,8 +100,8 @@ module OpenHAB
         #
         # rubocop: disable Style/OptionalBooleanParameter
         # Disabled cop due to use in a DSL
-        def on_start(run_on_start = true)
-          @on_start = run_on_start
+        def on_start(run_on_start = true, attach: nil)
+          @on_start = Struct.new(:enabled, :attach).new(run_on_start, attach)
         end
         # rubocop: enable Style/OptionalBooleanParameter
 
@@ -107,7 +111,16 @@ module OpenHAB
         # @return [Boolean] True if rule should run on start, false otherwise.
         #
         def on_start?
-          @on_start
+          @on_start.enabled
+        end
+
+        #
+        # Get the optional start attachment
+        #
+        # @return [Object] optional user provided attachment to the on_start method
+        #
+        def start_attachment
+          @on_start.attach
         end
 
         #
@@ -144,7 +157,8 @@ module OpenHAB
             "Run blocks: (#{run}) " \
             "on_start: (#{on_start?}) " \
             "Trigger Waits: #{trigger_delays} " \
-            "Trigger UIDs: #{triggers.map(&:id).join(', ')}"
+            "Trigger UIDs: #{triggers.map(&:id).join(', ')}" \
+            "Attachments: #{attachments} "
         end
       end
     end

--- a/lib/openhab/dsl/rules/triggers/channel.rb
+++ b/lib/openhab/dsl/rules/triggers/channel.rb
@@ -21,12 +21,12 @@ module OpenHAB
         # @param [String] triggered specific triggering condition to match for trigger
         #
         #
-        def channel(*channels, thing: nil, triggered: nil)
+        def channel(*channels, thing: nil, triggered: nil, attach: nil)
           channels.flatten.each do |channel|
             channel = [thing, channel].join(':') if thing
             logger.trace("Creating channel trigger for channel(#{channel}), thing(#{thing}), trigger(#{triggered})")
             [triggered].flatten.each do |trigger|
-              create_channel_trigger(channel, trigger)
+              create_channel_trigger(channel, trigger, attach)
             end
           end
         end
@@ -40,12 +40,12 @@ module OpenHAB
         # @param [Trigger] trigger specific channel trigger to match
         #
         #
-        def create_channel_trigger(channel, trigger)
+        def create_channel_trigger(channel, trigger, attach)
           config = { 'channelUID' => channel }
           config['event'] = trigger.to_s unless trigger.nil?
           config['channelUID'] = channel
           logger.trace("Creating Change Trigger for #{config}")
-          @triggers << Trigger.trigger(type: Trigger::CHANNEL_EVENT, config: config)
+          append_trigger(Trigger::CHANNEL_EVENT, config, attach: attach)
         end
       end
     end

--- a/lib/openhab/dsl/rules/triggers/command.rb
+++ b/lib/openhab/dsl/rules/triggers/command.rb
@@ -21,14 +21,14 @@ module OpenHAB
         # @param [Array] commands commands to match for trigger
         #
         #
-        def received_command(*items, command: nil, commands: nil)
+        def received_command(*items, command: nil, commands: nil, attach: nil)
           separate_groups(items).map do |item|
             logger.trace("Creating received command trigger for item(#{item})"\
                          "command(#{command}) commands(#{commands})")
 
             # Combine command and commands, doing union so only a single nil will be in the combined array.
             combined_commands = combine_commands(command, commands)
-            create_received_trigger(combined_commands, item)
+            create_received_trigger(combined_commands, item, attach)
           end.flatten
         end
 
@@ -41,7 +41,7 @@ module OpenHAB
         # @param [Object] item to create trigger for
         #
         #
-        def create_received_trigger(commands, item)
+        def create_received_trigger(commands, item, attach)
           commands.map do |command|
             if item.is_a? OpenHAB::DSL::Items::GroupItem::GroupMembers
               config, trigger = create_group_command_trigger(item)
@@ -49,7 +49,7 @@ module OpenHAB
               config, trigger = create_item_command_trigger(item)
             end
             config['command'] = command.to_s unless command.nil?
-            append_trigger(trigger, config)
+            append_trigger(trigger, config, attach: attach)
           end
         end
 

--- a/lib/openhab/dsl/rules/triggers/trigger.rb
+++ b/lib/openhab/dsl/rules/triggers/trigger.rb
@@ -46,9 +46,10 @@ module OpenHAB
         #
         # @return [Trigger] OpenHAB trigger
         #
-        def append_trigger(type, config)
+        def append_trigger(type, config, attach: nil)
           logger.trace("Creating trigger of type #{type} for #{config}")
           trigger = Trigger.trigger(type: type, config: config)
+          @attachments[trigger.id] = attach if attach
           @triggers << trigger
           trigger
         end

--- a/lib/openhab/dsl/rules/triggers/updated.rb
+++ b/lib/openhab/dsl/rules/triggers/updated.rb
@@ -19,12 +19,12 @@ module OpenHAB
         #
         # @return [Trigger] Trigger for updated entity
         #
-        def updated(*items, to: nil)
+        def updated(*items, to: nil, attach: nil)
           separate_groups(items).map do |item|
             logger.trace("Creating updated trigger for item(#{item}) to(#{to})")
             [to].flatten.map do |to_state|
               trigger, config = create_update_trigger(item, to_state)
-              append_trigger(trigger, config)
+              append_trigger(trigger, config, attach: attach)
             end
           end.flatten
         end


### PR DESCRIPTION
This is a WIP with RFC.

As I am converting more and more rules to jruby I am hitting the same pattern, in which I have multiple rules that are 99% similar but I want to do something slightly different based on the triggers, so I end up with duplicate rules.

For example:
```
def check_garage_doors(reason)
  open_doors = groups['GarageDoors'].select(&:open?)
  logging.debug("#{open_doors.length} garage doors open")
  open_doors.map{ |door| "#{reason} and #{door.label} is open" }
            .each { logger.warn(text); notify(text) }
end

rule 'Check garage doors at night' do
  every :day, at: '8pm'
  run { check_garage_doors "It's 8PM"}
end

rule 'Check garage doors when alarm armed for night' do
  changed Alarm_Mode, to: [10,14]
  run { check_garage_doors "Night mode set"}
end
```

The problems with this are:
1. The rule is almost exactly the same and so I copy and paste them - when you copy and paste it is a great way to create errors if not initially, later on when modifying.
2. I have to extract the check_garage_doors out to a method because I have multiple rules

I created a WIP for adding attachments to triggers, which would enable this instead:

```
def check_garage_doors(reason)
  open_doors = groups['GarageDoors'].select(&:open?)
  logging.debug("#{open_doors.length} garage doors open")
  open_doors.map{ |door| "#{reason} and #{door.label} is open" }
            .each { logger.warn(text); notify(text) }
end

rule 'Check if garage doors are open' do
  every :day, at: '8pm', attach: "It's 8PM"
  changed Alarm_Mode, to: [10,14], attach: 'Night mode set'
  run { |event| check_garage_doors(event.attachment)}
end
```

Now that it is a single rule, there is no need for the check_garage_doors method, but you could keep it if you want:

```
rule 'Check if garage doors are open' do
  every :day, at: '8pm', attach: "It's 8PM"
  changed Alarm_Mode, to: [10,14], attach: 'Night mode set'
  run do |event|
     reason = event.attachment
     open_doors = groups['GarageDoors'].select(&:open?)
     logging.debug("#{open_doors.length} garage doors open")
     open_doors.map{ |door| "#{reason} and #{door.label} is open" }
                        .each { logger.warn(text); notify(text) }
  end 
end
```

The other way to handle this is with looping, which I was doing in rules, but I think it is more difficult to understand what is going on:

```
Appliance = Struct.new(:name, :item, :url)
[Appliance.new("washer", Washer_Progress, Washer_Progress_URL), 
 Appliance.new("dryer", Dryer_Progress, Dryer_Progress_URL), ].each do |appliance|
  rule "Update #{appliance.name} chart URL" do
    changed appliance.item
    run do 
        progress = appliance.item&.state&.float_value || 0
        appliance.url << "https://quickchart.io/chart?c=" +ERB::Util.url_encode("{type:'radialGauge',data:{datasets:[{data:[#progress}],backgroundColor:'#283592'}]},options:{title:{display:true,text:'Progress',fontSize:20}}}"
    end
  end
end
```

would become:

```
rule "Update appliance chart URLs" do
  changed Washer_Progress, attach: Washer_Progress_URL
  changed Dryer_Progress, attach: Dryer_Progress_URL
  run |event| do 
      progress = event.item&.state&.float_value || 0
      url = event.attachment
      url << "https://quickchart.io/chart?c=" +ERB::Util.url_encode("{type:'radialGauge',data:{datasets:[{data:[#progress}],backgroundColor:'#283592'}]},options:{title:{display:true,text:'Progress',fontSize:20}}}"
    end
  end
end
```

You can attach arbitrary objects, arrays, hashes, etc.

Open items:
1. For the RFC I only did a WIP for changed, not the other triggers, although they will mostly be the same
2. I like 'attach:' for adding it to the trigger, I don't like 'attachment' to get the attached object
3. Not sure how to handle the 'triggered' execution block, could add to the item the event object. 

WDYT?


 


