### PR TITLE
feat(metadata): allow assignment to existing metadata config

### DIFF
--- a/docs/usage/misc/metadata.md
+++ b/docs/usage/misc/metadata.md
@@ -145,4 +145,13 @@ rule 'save event state' do
   changed StringItem1
   run { |event| Item1.meta['last_event'] = event.was }
 end
+
+# if the namespace already exists: Update the value of a namespace but preserve its config 
+# otherwise: create a new namespace with the given value and nil config
+Item1.meta['namespace'] = 'value', Item1.meta['namespace']
+
+# Copy another namespace
+# Item1's metadata before: { namespace2="value" [ config1="foo", config2="bar" ] }
+Item1.meta['namespace'] = Item1.meta['namespace2']
+# Item1's metadata after: { namespace2="value" [ config1="foo", config2="bar" ], namespace="value" [ config1="foo", config2="bar" ] }
 ```

--- a/lib/openhab/dsl/items/metadata.rb
+++ b/lib/openhab/dsl/items/metadata.rb
@@ -25,6 +25,7 @@ module OpenHAB
           extend Forwardable
 
           def_delegator :@metadata, :value
+          def_delegator :__getobj__, :to_h, :to_hash
 
           def initialize(metadata: nil, key: nil, value: nil, config: nil)
             @metadata = metadata || Metadata.new(key || MetadataKey.new('', ''), value&.to_s, config)
@@ -68,6 +69,7 @@ module OpenHAB
           # @return [Java::Org::openhab::core::items::Metadata] the old metadata
           #
           def config=(config)
+            config = config.to_hash if config.respond_to?(:to_hash)
             raise ArgumentError, 'Configuration must be a hash' unless config.is_a? Hash
 
             metadata = Metadata.new(@metadata&.uID, @metadata&.value, config)
@@ -158,7 +160,7 @@ module OpenHAB
             meta_value, configuration = update_from_value(value)
 
             key = MetadataKey.new(namespace, @item_name)
-            metadata = Metadata.new(key, meta_value&.to_s, configuration)
+            metadata = Metadata.new(key, meta_value&.to_s, configuration.to_h)
             # registry.get can be omitted, but registry.update will log a warning for nonexistent metadata
             if NamespaceAccessor.registry.get(key)
               NamespaceAccessor.registry.update(metadata)


### PR DESCRIPTION
Resolve #325 

This PR will allow using an existing metadata config in assignment:
```ruby
Item1.meta['ns1'].config = Item1.meta['ns2'] # copy the config of another namespace
Item1.meta['ns1'] = 'val', Item1.meta['ns1'] # update the metadata with the given value but use the same config
```

More details about the usefulness of this construct is explained in #325