### PR TITLE
fix(type): allow comparison against incompatible types

### DIFF
--- a/features/comparisons.feature
+++ b/features/comparisons.feature
@@ -530,6 +530,10 @@ Feature: comparisons
         [ OFF                         , '!='  , OFF                         , false ]  ,
         [ OFF                         , '!='  , UP                          , true  ]  ,
         [ OFF                         , '!='  , REFRESH                     , true  ]  ,
+
+        [ (0..100)                    , '===' , ON                          , false ]  ,
+        [ 50                          , '=='  , ON                          , false ]  ,
+        [ ON                          , '===' , PercentType.new(50)         , true  ]  ,
       ]
 
       def test_to_s(test)

--- a/features/dimmer_item.feature
+++ b/features/dimmer_item.feature
@@ -175,3 +175,30 @@ Feature:  dimmer_item
     And It should log "DimmerOne == 50? true" within 5 seconds
     And It should log "DimmerOne < 60? true" within 5 seconds
     And It should log "DimmerOne == DimmerTwo? true" within 5 seconds
+
+  Scenario Outline: Handle Numeric and OnOffType command in a case
+    Given code in a rules file
+      """
+      rule 'commanded' do
+        received_command DimmerOne
+        run do |event|
+          case event.command
+          when 0..49 then logger.info("up to 49%")
+          when 51..100 then logger.info("greater than 50%")
+          when 50 then logger.info("Exactly 50%")
+          when ON then logger.info("It is ON")
+          when OFF then logger.info("It is OFF")
+          end
+        end
+      end
+      DimmerOne << <state>
+      """
+    When I deploy the rules file
+    Then It should log "<log>" within 5 seconds
+    Examples:
+      | state | log              |
+      | ON    | It is ON         |
+      | OFF   | It is OFF        |
+      | "10"  | up to 49%        |
+      | "50"  | Exactly 50%      |
+      | "100" | greater than 50% |

--- a/lib/openhab/dsl/items/color_item.rb
+++ b/lib/openhab/dsl/items/color_item.rb
@@ -39,8 +39,6 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           return [other, nil] unless state?
           return [other, state] if other.is_a?(Types::HSBType) || other.respond_to?(:to_str)
-
-          raise TypeError, "can't convert #{other.class} into #{self.class}"
         end
 
         # any method that exists on {Types::HSBType} gets forwarded to +state+

--- a/lib/openhab/dsl/items/date_time_item.rb
+++ b/lib/openhab/dsl/items/date_time_item.rb
@@ -40,8 +40,6 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           return [other, nil] unless state?
           return [other, state] if other.is_a?(Types::DateTimeType) || other.respond_to?(:to_time)
-
-          raise TypeError, "can't convert #{other.class} into #{self.class}"
         end
 
         # any method that exists on DateTimeType, Java's ZonedDateTime, or

--- a/lib/openhab/dsl/items/location_item.rb
+++ b/lib/openhab/dsl/items/location_item.rb
@@ -39,8 +39,6 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           return [other, nil] unless state?
           return [other, state] if other.is_a?(Types::PointType) || other.respond_to?(:to_str)
-
-          raise TypeError, "can't convert #{other.class} into #{self.class}"
         end
 
         # OpenHAB has this method, but it _only_ accepts PointType, so remove it and delegate

--- a/lib/openhab/dsl/items/numeric_item.rb
+++ b/lib/openhab/dsl/items/numeric_item.rb
@@ -47,8 +47,6 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           return [other, nil] unless state?
           return [other, state] if other.is_a?(Types::NumericType) || other.respond_to?(:to_d)
-
-          raise TypeError, "can't convert #{other.class} into #{self.class}"
         end
 
         # strip trailing zeros from commands

--- a/lib/openhab/dsl/types/date_time_type.rb
+++ b/lib/openhab/dsl/types/date_time_type.rb
@@ -161,7 +161,8 @@ module OpenHAB
             time_string = "#{time_string}T00:00:00#{zone}" if DATE_ONLY_REGEX.match?(time_string)
             self <=> DateTimeType.parse(time_string)
           elsif other.respond_to?(:coerce)
-            lhs, rhs = other.coerce(self)
+            return nil unless (lhs, rhs = other.coerce(self))
+
             lhs <=> rhs
           end
         end
@@ -179,13 +180,11 @@ module OpenHAB
         def coerce(other)
           logger.trace("Coercing #{self} as a request from #{other.class}")
           if other.is_a?(Items::DateTimeItem)
-            raise TypeError, "can't convert #{UnDefType} into #{self.class}" unless other.state?
+            return unless other.state?
 
             [other.state, self]
           elsif other.respond_to?(:to_time)
             [DateTimeType.new(other), self]
-          else
-            raise TypeError, "can't convert #{other.class} into #{self.class}"
           end
         end
 
@@ -286,8 +285,7 @@ module OpenHAB
             self + other
           elsif other.respond_to?(:to_d)
             DateTimeType.new(zoned_date_time.plusNanos((other.to_d * 1_000_000_000).to_i))
-          elsif other.respond_to?(:coerce)
-            lhs, rhs = other.coerce(to_d)
+          elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
             lhs + rhs
           else
             raise TypeError, "\#{other.class} can't be coerced into \#{self.class}"
@@ -320,8 +318,7 @@ module OpenHAB
             self - other
           elsif other.respond_to?(:to_d)
             DateTimeType.new(zoned_date_time.minusNanos((other.to_d * 1_000_000_000).to_i))
-          elsif other.respond_to?(:coerce)
-            lhs, rhs = other.coerce(to_d)
+          elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
             lhs - rhs
           else
             raise TypeError, "\#{other.class} can't be coerced into \#{self.class}"

--- a/lib/openhab/dsl/types/decimal_type.rb
+++ b/lib/openhab/dsl/types/decimal_type.rb
@@ -87,7 +87,8 @@ module OpenHAB
           elsif other.respond_to?(:to_d)
             to_d <=> other.to_d
           elsif other.respond_to?(:coerce)
-            lhs, rhs = other.coerce(self)
+            return nil unless (lhs, rhs = other.coerce(self))
+
             lhs <=> rhs
           end
         end
@@ -109,15 +110,13 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           if other.is_a?(Items::NumericItem) ||
              (other.is_a?(Items::GroupItem) && other.base_item.is_a?(Items::NumericItem))
-            raise TypeError, "can't convert #{UnDefType} into #{self.class}" unless other.state?
+            return unless other.state?
 
             [other.state, self]
           elsif other.is_a?(Type)
             [other, as(other.class)]
           elsif other.respond_to?(:to_d)
             [self.class.new(other.to_d), self]
-          else
-            raise TypeError, "can't convert #{other.class} into #{self.class}"
           end
         end
 
@@ -150,8 +149,7 @@ module OpenHAB
             #     # result could already be a QuantityType
             #     result = self.class.new(result) unless result.is_a?(NumericType)
             #     result
-            #   elsif other.respond_to?(:coerce)
-            #     lhs, rhs = other.coerce(to_d)
+            #   elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
             #     lhs + rhs
             #   else
             #     raise TypeError, "#{other.class} can't be coerced into #{self.class}"
@@ -168,8 +166,7 @@ module OpenHAB
                   # result could already be a QuantityType
                   result = self.class.new(result) unless result.is_a?(NumericType)
                   result
-                elsif other.respond_to?(:coerce)
-                  lhs, rhs = other.coerce(to_d)
+                elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
                   lhs #{ruby_op} rhs
                 else
                   raise TypeError, "\#{other.class} can't be coerced into \#{self.class}"

--- a/lib/openhab/dsl/types/hsb_type.rb
+++ b/lib/openhab/dsl/types/hsb_type.rb
@@ -133,7 +133,7 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           if other.is_a?(Items::NumericItem) ||
              (other.is_a?(Items::GroupItem) && other.base_item.is_a?(Items::NumericItem))
-            raise TypeError, "can't convert #{UnDefType} into #{self.class}" unless other.state?
+            return unless other.state?
 
             [other.state, self]
           elsif other.respond_to?(:to_str)

--- a/lib/openhab/dsl/types/quantity_type.rb
+++ b/lib/openhab/dsl/types/quantity_type.rb
@@ -61,7 +61,8 @@ module OpenHAB
           elsif other.respond_to?(:to_d)
             compare_to(QuantityType.new(other.to_d.to_java, Units.unit || unit))
           elsif other.respond_to?(:coerce)
-            lhs, rhs = other.coerce(self)
+            return nil unless (lhs, rhs = other.coerce(self))
+
             lhs <=> rhs
           end
         end
@@ -82,7 +83,7 @@ module OpenHAB
           logger.trace("Coercing #{self} as a request from #{other.class}")
           if other.is_a?(Items::NumericItem) ||
              (other.is_a?(Items::GroupItem) && other.base_item.is_a?(Items::NumericItem))
-            raise TypeError, "can't convert #{UnDefType} into #{self.class}" unless other.state?
+            return unless other.state?
 
             [other.state, self]
           elsif other.is_a?(Type)
@@ -91,8 +92,6 @@ module OpenHAB
             [QuantityType.new(other.to_d.to_java, ONE), self]
           elsif other.is_a?(String)
             [QuantityType.new(other), self]
-          else
-            raise TypeError, "can't convert #{other.class} into #{self.class}"
           end
         end
 
@@ -123,9 +122,8 @@ module OpenHAB
             #   elsif other.respond_to?(:to_d)
             #     other = other.to_d.to_java
             #     add_quantity(self.class.new(other, Units.unit || unit))
-            #   elsif other.respond_to?(:coerce)
-            #     lhs, rhs = other.coerce(to_d)
-            #     lhs = rhs
+            #   elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
+            #     lhs + rhs
             #   else
             #     raise TypeError, "#{other.class} can't be coerced into #{self.class}"
             #   end
@@ -148,8 +146,7 @@ module OpenHAB
                 elsif other.respond_to?(:to_d)
                   other = other.to_d.to_java
                   #{java_op}_quantity(#{convert})
-                elsif other.respond_to?(:coerce)
-                  lhs, rhs = other.coerce(to_d)
+                elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
                   lhs #{ruby_op} rhs
                 else
                   raise TypeError, "\#{other.class} can't be coerced into \#{self.class}"
@@ -179,8 +176,7 @@ module OpenHAB
             #     self * self.class.new(other)
             #   elsif other.respond_to?(:to_d)
             #     multiply(other.to_d.to_java)
-            #   elsif other.respond_to?(:coerce)
-            #     lhs, rhs = other.coerce(to_d)
+            #   elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
             #     lhs * rhs
             #   else
             #     raise TypeError, "#{other.class} can't be coerced into #{self.class}"
@@ -202,8 +198,7 @@ module OpenHAB
                   self #{ruby_op} self.class.new(other)
                 elsif other.respond_to?(:to_d)
                   #{java_op}(other.to_d.to_java)
-                elsif other.respond_to?(:coerce)
-                  lhs, rhs = other.coerce(to_d)
+                elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
                   lhs #{ruby_op} rhs
                 else
                   raise TypeError, "\#{other.class} can't be coerced into \#{self.class}"

--- a/lib/openhab/dsl/types/string_type.rb
+++ b/lib/openhab/dsl/types/string_type.rb
@@ -52,7 +52,8 @@ module OpenHAB
           elsif other.respond_to?(:to_str)
             to_str <=> other.to_str
           elsif other.respond_to?(:coerce)
-            lhs, rhs = other.coerce(self)
+            return nil unless (lhs, rhs = other.coerce(self))
+
             lhs <=> rhs
           end
         end
@@ -70,13 +71,11 @@ module OpenHAB
         def coerce(other)
           logger.trace("Coercing #{self} as a request from #{other.class}")
           if other.is_a?(Items::StringItem)
-            raise TypeError, "can't convert #{other.raw_state} into #{self.class}" unless other.state?
+            return unless other.state?
 
             [other.state, self]
           elsif other.respond_to?(:to_str)
             [String.new(other.to_str), self]
-          else
-            raise TypeError, "can't convert #{other.class} into #{self.class}"
           end
         end
 


### PR DESCRIPTION
fixes #328

ruby actually allows coerce to return nil (see
https://github.com/jruby/jruby/blob/9.2.19.0/core/src/main/java/org/jruby/RubyRange.java#L755,
https://github.com/jruby/jruby/blob/a309a88614916621de4cc5dc3693f279dae58d0c/core/src/main/java/org/jruby/RubyNumeric.java#L640,
https://github.com/ruby/ruby/blob/4fb71575e270092770951e6a69bf006c71fadb55/numeric.c#L477)

in light of that, don't raise TypeError ourselves in coerce methods, but
update our uses of coerce to check the return value, and handle
appropriately:
 * return nil from <=> if coercion failed
 * return false from == if coercion failed
 * raise a type error in arithmetic operations if coercion failed