### PR TITLE
fix(logging): use the class name not "Class" for class-level loggers

### DIFF
--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -45,7 +45,7 @@ module OpenHAB
       #
       def logger
         if @rule_name
-          Log.logger(@rule_name.chomp.gsub(/\s+/, '_'))
+          Log.logger_for(@rule_name.chomp.gsub(/\s+/, '_'))
         else
           super
         end

--- a/lib/openhab/dsl/rules/rule_config.rb
+++ b/lib/openhab/dsl/rules/rule_config.rb
@@ -127,7 +127,7 @@ module OpenHAB
         #
         def logger
           if name
-            Log.logger(name.chomp.gsub(/\s+/, '_'))
+            Log.logger_for(name.chomp.gsub(/\s+/, '_'))
           else
             super
           end

--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -137,31 +137,36 @@ module OpenHAB
     # @return [Logger] for the current class
     #
     def logger
-      Log.logger(self.class.name)
+      Log.logger(self.class)
     end
 
     class << self
       #
       # Injects a logger into the base class
       #
-      # @param [String] name of the logger
+      # @param [Class] class the logger is for
       #
       # @return [Logger] for the supplied name
       #
-      def logger(name)
-        name ||= self.class.name
+      def logger(klass)
+        if klass.respond_to?(:java_class) &&
+           klass.java_class &&
+           !klass.java_class.name.start_with?('org.jruby.Ruby')
+          klass = klass.java_class
+        end
+        name = klass.name
         @loggers[name] ||= Log.logger_for(name)
       end
 
       #
       # Configure a logger for the supplied class name
       #
-      # @param [String] classname to configure logger for
+      # @param [String] name to configure logger for
       #
       # @return [Logger] for the supplied classname
       #
-      def logger_for(classname)
-        configure_logger_for(classname)
+      def logger_for(name)
+        configure_logger_for(name)
       end
 
       private
@@ -173,10 +178,10 @@ module OpenHAB
       #
       # @return [Logger] Logger for the supplied classname
       #
-      def configure_logger_for(classname)
+      def configure_logger_for(name)
         log_prefix = Configuration.log_prefix
-        log_prefix += if classname
-                        ".#{classname}"
+        log_prefix += if name
+                        ".#{name}"
                       else
                         ".#{log_caller}"
                       end
@@ -207,7 +212,7 @@ module OpenHAB
     def self.included(base)
       class << base
         def logger
-          Log.logger(self.class.name)
+          Log.logger(self)
         end
       end
     end


### PR DESCRIPTION
also use the java class's name if it's a java class. means getting things
like org.openhab.core.types.RefreshType instead of
Java::OrgOpenHabCoreTypes::RefreshType