### PR TITLE
fix(changed): changed trigger now supports multiple from values

### DIFF
--- a/features/changed.feature
+++ b/features/changed.feature
@@ -208,3 +208,22 @@ Feature:  changed
       | Switch3  | ON    |
       | Contact3 | OPEN  |
 
+  Scenario Outline: Item changed from one of many matching item states
+    Given items:
+      | type   | name       | state        |
+      | Number | Alarm_Mode | <from_state> |
+    And a rule
+      """
+      rule 'Execute rule when item is changed to specific number' do
+      changed Alarm_Mode, from: [10,14]
+      run { logger.info("Alarm Mode: Updated from <from_state> to <to_state>")}
+      end
+      """
+    When I deploy the rule
+    And item "Alarm_Mode" state is changed to "<to_state>"
+    Then It <should> log 'Alarm Mode: Updated from <from_state> to <to_state>' within 5 seconds
+    Examples:
+      | from_state | to_state | should     |
+      | 10         | 11       | should     |
+      | 11         | 12       | should not |
+      | 14         | 15       | should     |

--- a/lib/openhab/dsl/rules/triggers/changed.rb
+++ b/lib/openhab/dsl/rules/triggers/changed.rb
@@ -39,7 +39,7 @@ module OpenHAB
             else
               # Place in array and flatten to support multiple to elements or single or nil
               [to].flatten.each do |to_state|
-                create_changed_trigger(item, from, to_state)
+                [from].flatten.each { |from_state| create_changed_trigger(item, from_state, to_state) }
               end
             end
           end


### PR DESCRIPTION
The docs https://boc-tothefuture.github.io/openhab-jruby/usage/triggers/changed/ suggests that both from: and to: can support multiple states, but it wasn't implemented for the from: parameter. 

This PR adds the support for multiple from values for the changed trigger.
