### PR TITLE
fix(triggers): trigger methods return the trigger objects

### DIFF
--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -98,6 +98,26 @@ Feature: rule_language
     And item "TestSwitch" state is changed to "ON"
     Then It should log 'switch changed' within 5 seconds
 
+  Scenario Outline: Triggers return an OpenHAB TriggerImpl object
+    Given items:
+      | type   | name       |
+      | Number | Alarm_Mode |
+    And a rule
+      """
+      rule 'Check trigger return value' do
+        trigger = <trigger> Alarm_Mode
+        logger.info("<trigger> returns #{trigger&.first&.class}")
+        run { }
+      end
+      """
+    When I deploy the rules file
+    Then It should log '<trigger> returns Java::OrgOpenhabCoreAutomationInternal::TriggerImpl' within 5 seconds
+    Examples:
+      | trigger          |
+      | updated          |
+      | changed          |
+      | received_command |
+
   Scenario: Rule logs a warning and isn't created if it contains no execution blocks
     Given a rule
       """
@@ -151,10 +171,10 @@ Feature: rule_language
     And It should log "in `<main>'" within 5 seconds
     But It should not log 'This one works!' within 10 seconds
     Examples: Checks different block types
-    | block   |
-    | run     |
-    | only_if | 
-    | not_if  |
+      | block   |
+      | run     |
+      | only_if |
+      | not_if  |
 
   @log_level_changed
   Scenario: Native java exceptions are handled

--- a/lib/openhab/dsl/rules/triggers/changed.rb
+++ b/lib/openhab/dsl/rules/triggers/changed.rb
@@ -31,18 +31,18 @@ module OpenHAB
         # @return [Trigger] OpenHAB trigger
         #
         def changed(*items, to: nil, from: nil, for: nil)
-          separate_groups(items).each do |item|
+          separate_groups(items).map do |item|
             logger.trace("Creating changed trigger for entity(#{item}), to(#{to}), from(#{from})")
             # for is a reserved word in ruby, so use local_variable_get :for
             if (wait_duration = binding.local_variable_get(:for))
               changed_wait(item, to: to, from: from, duration: wait_duration)
             else
               # Place in array and flatten to support multiple to elements or single or nil
-              [to].flatten.each do |to_state|
-                [from].flatten.each { |from_state| create_changed_trigger(item, from_state, to_state) }
+              [to].flatten.map do |to_state|
+                [from].flatten.map { |from_state| create_changed_trigger(item, from_state, to_state) }
               end
             end
-          end
+          end.flatten
         end
 
         private
@@ -55,12 +55,13 @@ module OpenHAB
         # @param [Item State] to OpenHAB Item State item or group needs to change to
         # @param [Item State] from OpenHAB Item State item or group needs to be coming from
         #
-        # @return [Array] Array of current TriggerDelay objects
+        # @return [Trigger] OpenHAB trigger
         #
         def changed_wait(item, duration:, to: nil, from: nil)
           trigger = create_changed_trigger(item, nil, nil)
           logger.trace("Creating Changed Wait Change Trigger for #{item}")
           @trigger_delays[trigger.id] = TriggerDelay.new(to: to, from: from, duration: duration)
+          trigger
         end
 
         #

--- a/lib/openhab/dsl/rules/triggers/command.rb
+++ b/lib/openhab/dsl/rules/triggers/command.rb
@@ -22,14 +22,14 @@ module OpenHAB
         #
         #
         def received_command(*items, command: nil, commands: nil)
-          separate_groups(items).each do |item|
+          separate_groups(items).map do |item|
             logger.trace("Creating received command trigger for item(#{item})"\
                          "command(#{command}) commands(#{commands})")
 
             # Combine command and commands, doing union so only a single nil will be in the combined array.
             combined_commands = combine_commands(command, commands)
             create_received_trigger(combined_commands, item)
-          end
+          end.flatten
         end
 
         private
@@ -42,7 +42,7 @@ module OpenHAB
         #
         #
         def create_received_trigger(commands, item)
-          commands.each do |command|
+          commands.map do |command|
             if item.is_a? OpenHAB::DSL::Items::GroupItem::GroupMembers
               config, trigger = create_group_command_trigger(item)
             else

--- a/lib/openhab/dsl/rules/triggers/updated.rb
+++ b/lib/openhab/dsl/rules/triggers/updated.rb
@@ -20,13 +20,13 @@ module OpenHAB
         # @return [Trigger] Trigger for updated entity
         #
         def updated(*items, to: nil)
-          separate_groups(items).each do |item|
+          separate_groups(items).map do |item|
             logger.trace("Creating updated trigger for item(#{item}) to(#{to})")
-            [to].flatten.each do |to_state|
+            [to].flatten.map do |to_state|
               trigger, config = create_update_trigger(item, to_state)
               append_trigger(trigger, config)
             end
-          end
+          end.flatten
         end
 
         private


### PR DESCRIPTION
The source code documentation stated that trigger methods (update, changed, received_command) return the OpenHAB triggers. However they just return the items being passed to them. 

This PR makes a slight modification so that these methods return the openhab trigger objects.

