### PR TITLE
refactor(imports): remove extraneous java_import

### DIFF
--- a/lib/openhab/core/osgi.rb
+++ b/lib/openhab/core/osgi.rb
@@ -11,7 +11,6 @@ module OpenHAB
     class OSGI
       include OpenHAB::Log
 
-      java_import org.openhab.core.model.script.actions.ScriptExecution
       java_import org.osgi.framework.FrameworkUtil
 
       #

--- a/lib/openhab/dsl/rules/triggers/cron.rb
+++ b/lib/openhab/dsl/rules/triggers/cron.rb
@@ -10,9 +10,6 @@ module OpenHAB
       # Cron type rules
       #
       module Triggers
-        java_import org.openhab.core.automation.util.TriggerBuilder
-        java_import org.openhab.core.config.core.Configuration
-
         #
         # Returns a default map for cron expressions that fires every second
         # This map is usually updated via merge by other methods to refine cron type triggers.

--- a/lib/openhab/dsl/things.rb
+++ b/lib/openhab/dsl/things.rb
@@ -47,7 +47,7 @@ module OpenHAB
 
         private
 
-        java_import 'org.openhab.core.automation.annotation.RuleAction'
+        java_import org.openhab.core.automation.annotation.RuleAction
 
         #
         # Define methods from actions mapped to this thing


### PR DESCRIPTION
I could only find three extra java_imports, so it's a very tiny PR.