### PR TITLE
fix(reentrant_timer): reset the timer duration to the latest call

### DIFF
--- a/features/timer.feature
+++ b/features/timer.feature
@@ -157,8 +157,8 @@ Feature:  timer
     When I wait 2 seconds
     And I remove the rules file
     Then It should not log 'Timer Fired' within 10 seconds
-    
-   Scenario: Timers with IDs specified are reeentrant
+
+  Scenario: Timers with IDs specified are reeentrant
     Given items:
       | type   | name       | label      |
       | Number | Alarm_Mode | Alarm Mode |
@@ -182,7 +182,7 @@ Feature:  timer
     But If I wait 3 seconds
     Then It should log 'Timer Fired' within 5 seconds
 
-   
+
   Scenario: Timers can be retrieved by id
     Given code in a rules file:
       """
@@ -198,4 +198,17 @@ Feature:  timer
     When I deploy the rule
     Then It should not log 'Timer Fired' within 5 seconds
 
+  Scenario: Reentrant timer will change its duration to the latest call
+    Given code in a rules file
+      """
+      [10, 5, 1].each do |duration|
+        after duration.seconds, id: :test do
+          logger.info("Timer Fired after #{duration} seconds")
+        end
+      end
+      """
+    When I deploy the rules file
+    Then It should log 'Timer Fired after 1 seconds' within 2 seconds
+    And It should not log 'Timer Fired after 5 seconds' within 7 seconds
+    And It should not log 'Timer Fired after 10 seconds' within 12 seconds
 

--- a/lib/openhab/dsl/timers.rb
+++ b/lib/openhab/dsl/timers.rb
@@ -58,11 +58,11 @@ module OpenHAB
         timer = @timer_manager.reentrant_timer(id: id, &block)
         if timer
           logger.trace("Reentrant timer found - #{timer}")
-          timer.reschedule
+          timer.cancel
         else
           logger.trace('No reentrant timer found, creating new timer')
-          ReentrantTimer.new(duration: duration, id: id, &block)
         end
+        ReentrantTimer.new(duration: duration, id: id, &block)
       end
     end
   end


### PR DESCRIPTION
Resolves #342

Whenever a timer is "re-entered", the existing timer simply gets cancelled (and therefore removed from timer manager) and then a new one is created. This is done so the resulting timer gets the new duration and it will therefore use it for subsequent `#reschedule`.

Note that openhab's own implementation for reschedule is the same - it would cancel the current timer and create a new timer. https://github.com/openhab/openhab-core/blob/79edf2b9e643ad802c31b2e5f54edb93534277fd/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java#L55-L61 
