### PR TITLE
fix(dev): target ruby 2.6

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  RUBY_VERSION: 2.5
+  RUBY_VERSION: 2.6
   GITHUB_TOKEN: ${{ github.token }}
 
 jobs:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_mode:
     - Exclude # we want our Exclude to build on the excludes from the default config
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Exclude:
     - bin/*

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -21,7 +21,7 @@ JRuby Scripting OpenHAB is GitHub repo is [here](https://github.com/boc-tothefut
 # Development Environment Setup
 The development process has been tested on MacOS, others operating systems may work. 
 
-1. Install Ruby 2.5.8 - Recommended method is using [rbenv](https://github.com/rbenv/rbenv#installation)
+1. Install Ruby 2.6.8 - Recommended method is using [rbenv](https://github.com/rbenv/rbenv#installation)
 2. Fork [the repo](https://github.com/boc-tothefuture/openhab-jruby) and clone it
 3. Install [bundler](https://bundler.io/)
 4. Run `bundler install` from inside of the repo directory

--- a/docs/usage/items.md
+++ b/docs/usage/items.md
@@ -16,7 +16,7 @@ All items can be accessed as an enumerable the `items` method.
 |--------------------|--------------------------------------------------------------------------------|
 | []                 | Get a specific item by name, this syntax can be used to dynamically load items |
 | include?           | Check to see if an item with the given name exists                             |
-| enumerable methods | All methods [here](https://ruby-doc.org/core-2.5.0/Enumerable.html)            |
+| enumerable methods | All methods [here](https://ruby-doc.org/core-2.6.8/Enumerable.html)            |
 
 ## Examples
 
@@ -69,7 +69,7 @@ Item types have methods added to them to make it flow naturally within the a rub
 
 State returns nil instead of UNDEF or NULL so that it can be used with with [Ruby safe navigation operator](https://ruby-doc.org/core-2.6/doc/syntax/calling_methods_rdoc.html) `&.`  Use `undef?` or `null?` to check for those states.
 
-To operate across an arbitrary collection of items you can place them in an [array](https://ruby-doc.org/core-2.5.0/Array.html) and execute methods against the array.
+To operate across an arbitrary collection of items you can place them in an [array](https://ruby-doc.org/core-2.6.8/Array.html) and execute methods against the array.
 
 ```ruby
 number_items = [Livingroom_Temp, Bedroom_Temp]

--- a/docs/usage/items/datetime.md
+++ b/docs/usage/items/datetime.md
@@ -10,7 +10,7 @@ grand_parent: Usage
 # DateTimeItem
 
 DateTime items are extended with a lot of methods that make working with them easy. Most of the methods
-defined by the [ruby Time class](https://ruby-doc.org/core-2.5.8/Time.html) are available, and some of 
+defined by the [ruby Time class](https://ruby-doc.org/core-2.6.8/Time.html) are available, and some of 
 them are extended or adapted with OpenHAB specific functionality.
 
 ##### Examples

--- a/docs/usage/items/groups.md
+++ b/docs/usage/items/groups.md
@@ -10,7 +10,7 @@ grand_parent: Usage
 # Groups
 
 A group can be accessed directly by name, to access all groups use the `groups` method. A Group behaves like a regular Item, but also lets you iterate through it's members and use all the available methods of 
-[Enumerable](https://ruby-doc.org/core-2.5.0/Enumerable.html). If the group have a type all methods of that type is directly available.
+[Enumerable](https://ruby-doc.org/core-2.6.8/Enumerable.html). If the group have a type all methods of that type is directly available.
 
 
 ## Group Methods
@@ -20,7 +20,7 @@ A group can be accessed directly by name, to access all groups use the `groups` 
 | members            | Used to inform a rule that you want it to operate on the items in the group (see example below) |
 | all_members        | Gets all descendants of the group recursively excluding groups. Pass :all as argument to include groups as well, or :groups to only get the sub groups. It's also possible to pass a block to make more advanced filters |
 | each               | Iterates through the members of the group and execute the code in the provided block for each member |
-| enumerable methods | All methods [here](https://ruby-doc.org/core-2.5.0/Enumerable.html)                             |
+| enumerable methods | All methods [here](https://ruby-doc.org/core-2.6.8/Enumerable.html)                             |
 
 ## Use in triggers
 
@@ -94,7 +94,7 @@ rule 'Turn off any switch that changes' do
 end
 ```
 
-Built in [enumerable](https://ruby-doc.org/core-2.5.1/Enumerable.html)/[set](https://ruby-doc.org/stdlib-2.5.1/libdoc/set/rdoc/Set.html) functions can be applied to groups.  
+Built in [enumerable](https://ruby-doc.org/core-2.6.8/Enumerable.html)/[set](https://ruby-doc.org/stdlib-2.6.8/libdoc/set/rdoc/Set.html) functions can be applied to groups.  
 ```ruby
 logger.info("Max is #{Temperatures.max}")
 logger.info("Min is #{Temperatures.min}")

--- a/docs/usage/items/number.md
+++ b/docs/usage/items/number.md
@@ -19,9 +19,9 @@ grand_parent: Usage
 | to_i            |            | Returns the state as an Integer or nil if state is UNDEF or NULL                                                                                             | `NumberOne.to_i`                                                             |
 | to_f            |            | Returns the state as a Float or nil if state is UNDEF or NULL                                                                                                | `NumberOne.to_f`                                                             |
 | dimension       |            | Returns the dimension of the Number Item, nil if the number is dimensionless                                                                                 | `Numberone.dimension`                                                        |
-| Numeric Methods |            | All methods for [Ruby Numeric](https://ruby-doc.org/core-2.5.0/Numeric.html)                                                                                 |                                                                              |
+| Numeric Methods |            | All methods for [Ruby Numeric](https://ruby-doc.org/core-2.6.8/Numeric.html)                                                                                 |                                                                              |
 
- Math operations for dimensionless numbers return a type of [Ruby BigDecimal](https://ruby-doc.org/stjjdlib-2.5.1/libdoc/bigdecimal/rdoc/BigDecimal.html).  Check [Quantities section](#quantities) for details of how math operations impact dimensioned numbers. 
+ Math operations for dimensionless numbers return a type of [Ruby BigDecimal](https://ruby-doc.org/stdlib-2.6.8/libdoc/bigdecimal/rdoc/BigDecimal.html).  Check [Quantities section](#quantities) for details of how math operations impact dimensioned numbers. 
 
 
 ## Examples

--- a/docs/usage/items/string.md
+++ b/docs/usage/items/string.md
@@ -12,7 +12,7 @@ grand_parent: Usage
 | Method          | Parameters | Description                                                                | Example                                          |
 | --------------- | ---------- | -------------------------------------------------------------------------- | ------------------------------------------------ |
 | truthy?         |            | Item state not UNDEF, not NULL and is not blank ('') when trimmed.         | `puts "#{item.name} is truthy" if item.truthy?`  |
-| String methods* |            | All methods for [Ruby String](https://ruby-doc.org/core-2.5.1/String.html) | `StringOne << StringOne + ' World!'`             |
+| String methods* |            | All methods for [Ruby String](https://ruby-doc.org/core-2.6.8/String.html) | `StringOne << StringOne + ' World!'`             |
 | blank?          |            | True if state is UNDEF, NULL, string is empty or contains only whitespace  | `StringOne << StringTwo unless StringTwo.blank?` |
 
 * All String methods returns a copy of the current state as a string.  Methods that modify a string in place, do not modify the underlying state string. 

--- a/docs/usage/misc/duration.md
+++ b/docs/usage/misc/duration.md
@@ -8,8 +8,8 @@ grand_parent: Usage
 ---
 
 # Duration
-Ruby [integers](https://ruby-doc.org/core-2.5.0/Integer.html) and
-[floats](https://ruby-doc.org/core-2.5.0/Float.html) are extended with several
+Ruby [integers](https://ruby-doc.org/core-2.6.8/Integer.html) and
+[floats](https://ruby-doc.org/core-2.6.8/Float.html) are extended with several
 methods to support durations. These methods create a new
 [java.time.Duration](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html)
 object that is used by the [Every trigger](../../triggers/every/),

--- a/docs/usage/misc/metadata.md
+++ b/docs/usage/misc/metadata.md
@@ -9,7 +9,7 @@ grand_parent: Usage
 
 # Item Metadata
 
-Item metadata can be accessed through `Item.meta` using the hash syntax. The `Item.meta` variable is also an [Enumerable](https://ruby-doc.org/core-2.5.8/Enumerable.html).
+Item metadata can be accessed through `Item.meta` using the hash syntax. The `Item.meta` variable is also an [Enumerable](https://ruby-doc.org/core-2.6.8/Enumerable.html).
 
 In addition to the Enumerable methods, the following methods are available for `Item.meta`:
 

--- a/docs/usage/things.md
+++ b/docs/usage/things.md
@@ -15,7 +15,7 @@ Things can be access using the `things` method and subsequent operations on that
 | ------------------ | ------------------------------------------------------------------- |
 | things             | Return all things as a Ruby Set                                     |
 | []                 | Get a specific thing by name                                        |
-| enumerable methods | All methods [here](https://ruby-doc.org/core-2.5.0/Enumerable.html) |
+| enumerable methods | All methods [here](https://ruby-doc.org/core-2.6.8/Enumerable.html) |
 
 ```ruby
 things.each { |thing| logger.info("Thing: #{thing.uid}")}

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'JRuby Helper Libraries for OpenHAB Scripting'
   spec.description   = 'JRuby Helper Libraries for OpenHAB Scripting'
   spec.homepage      = 'https://boc-tothefuture.github.io/openhab-jruby/'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   #  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 


### PR DESCRIPTION
 * change rubocop target
 * update gemspec requirements (this means if you don't
   upgrade the jruby bundle in openhab it will refuse to install any
   future versions of the gem, which will have been tested against
   ruby 2.6/jruby 9.3)
 * update github workflow to use ruby 2.6
 * update any documentation links to use 2.6.8 instead of 2.5.x