### PR TITLE
fix(script_handling): scriptLoaded and scriptUnloaded not executed

### DIFF
--- a/lib/openhab.rb
+++ b/lib/openhab.rb
@@ -23,13 +23,13 @@ module OpenHAB
   def self.extended(base)
     OpenHAB::Core.wait_till_openhab_ready
     base.extend Log
-    base.extend OpenHAB::Core::ScriptHandling
     base.extend OpenHAB::Core::EntityLookup
     base.extend OpenHAB::DSL
     base.extend OpenHAB::DSL::Between
 
     base.send :include, OpenHAB::DSL::Items
     base.send :include, OpenHAB::DSL::Types
+    base.send :include, OpenHAB::Core::ScriptHandling
     logger.info "OpenHAB JRuby Scripting Library Version #{OpenHAB::VERSION} Loaded"
 
     OpenHAB::Core.add_rubylib_to_load_path

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -150,6 +150,7 @@ namespace :openhab do
       mkdir_p gem_home
       mkdir_p ruby_lib_dir
       services_config = ERB.new <<~SERVICES
+        org.openhab.automation.jrubyscripting:local_context=threadsafe
         org.openhab.automation.jrubyscripting:gem_home=<%= gem_home %>
         org.openhab.automation.jrubyscripting:rubylib=<%= ruby_lib_dir %>
       SERVICES


### PR DESCRIPTION
Two things fixed #396 and #366 

- Use `singlethread` instead of `threadsafe` - this is the main cause of the problem
- Use include instead of extend for `OpenHAB::Core::ScriptHandling` 

Someone more knowledgeable can probably explain this better. According to https://github.com/jruby/jruby/wiki/RedBridge#Context_Instance_Type In `threadsafe`, there's only a single ScriptingContainer, shared across all the engine instances(?) I am not sure whether this means that the namespace for methods are shared?

In `singlethead` (and  also `singleton`) mode, each engine gets its own ScriptingContainer. 

This will require changing the default local_context to 'singlethread' within the automation add-on, as well as updating its docs.