### PR TITLE
ci(bundle): use the official bundle

### DIFF
--- a/features/gem_install.feature
+++ b/features/gem_install.feature
@@ -11,7 +11,7 @@ Feature:  gem_install
     And a services template filed named "jruby.cfg"
       """
       org.openhab.automation.jrubyscripting:gem_home=<%= gem_home %>
-      org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>3.0
+      org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>4.0
       org.openhab.automation.jrubyscripting:rubylib=<%= ruby_lib_dir %>
       """
     And code in a rules file:
@@ -19,7 +19,7 @@ Feature:  gem_install
       logger.info("OpenHAB helper library is at #{OpenHAB::VERSION}")
       """
     When I start OpenHAB
-    Then It should log 'Installing Gem: openhab-scripting' within 120 seconds
+    Then It should log 'Installing Gem: openhab-scripting' within 180 seconds
     And I deploy the rules file
-    Then It should log 'OpenHAB helper library is at' within 160 seconds
+    Then It should log 'OpenHAB helper library is at' within 200 seconds
 

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -75,7 +75,7 @@ def ruby_lib_dir
 end
 
 def gem_home
-  File.join(openhab_dir, 'conf/automation/lib/ruby/gem_home')
+  File.join(openhab_dir, 'conf/scripts/lib/ruby/gem_home')
 end
 
 def services_dir

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -11,7 +11,7 @@ require 'digest/md5'
 # rubocop: disable Rake/MethodDefinitionInTask Legacy code
 namespace :openhab do
   @openhab_version = ENV['OPENHAB_VERSION'] || '3.1.0'
-  @jruby_bundle = 'https://github.com/boc-tothefuture/openhab2-addons/releases/download/3.2.0/org.openhab.automation.jrubyscripting-3.2.0-SNAPSHOT.jar'
+  @jruby_bundle = 'https://ci.openhab.org/job/openHAB-Addons/lastStableBuild/artifact/bundles/org.openhab.automation.jrubyscripting/target/org.openhab.automation.jrubyscripting-3.2.0-SNAPSHOT.jar'
   karaf_client_path = File.join(OPENHAB_DIR, 'runtime/bin/client')
   karaf_client_args = [karaf_client_path, '-p', 'habopen'].freeze
   @karaf_client = karaf_client_args.join(' ')
@@ -89,7 +89,7 @@ namespace :openhab do
 
   def gem_home
     full_path = File.realpath OPENHAB_DIR
-    File.join(full_path, '/conf/automation/lib/ruby/gem_home')
+    File.join(full_path, '/conf/scripts/lib/ruby/gem_home')
   end
 
   def ruby_lib_dir
@@ -150,7 +150,6 @@ namespace :openhab do
       mkdir_p gem_home
       mkdir_p ruby_lib_dir
       services_config = ERB.new <<~SERVICES
-        org.openhab.automation.jrubyscripting:local_context=threadsafe
         org.openhab.automation.jrubyscripting:gem_home=<%= gem_home %>
         org.openhab.automation.jrubyscripting:rubylib=<%= ruby_lib_dir %>
       SERVICES
@@ -181,7 +180,8 @@ namespace :openhab do
   task :upgrade, [:file] do |_, args|
     start
     if karaf('bundle:list --no-format org.openhab.automation.jrubyscripting').include?('Active')
-      karaf("bundle:update #{bundle_id} file://#{args[:file]}")
+      source = args[:file] ? "file://#{args[:file]}" : @jruby_bundle
+      karaf("bundle:update #{bundle_id} #{source}")
     else
       abort "Bundle not installed, can't upgrade"
     end


### PR DESCRIPTION
This PR does 4 things:

- Make the rake openhab:update command without a file argument to pull the snapshot bundle remotely
- Change the bundle source url to the snapshot build from openhab-addons since the bundle has been merged into openhab
- Because the bundle sets the default local_context to singlethread, remove `local_context` setting from the test environment, as it shouldn't even be set to `threadsafe` anyway.
- Set the gem_home to conf/scripts/lib/..... instead of conf/automation/lib/...
