### PR TITLE
fix(logging): multiple logging path fixes

### DIFF
--- a/docs/usage/misc/logging.md
+++ b/docs/usage/misc/logging.md
@@ -9,13 +9,35 @@ grand_parent: Usage
 
 # Logging
 
-Logging is available everywhere through the logger object.  The name of the rule file is automatically appended to the logger name. Pending [merge](https://github.com/openhab/openhab-core/pull/1885) into the core.
+Logging is available everywhere through the logger object. The name of the rule file is automatically appended to the logger name.
 
 ```ruby
 logger.trace('Test logging at trace') # 2020-12-03 18:05:20.903 [TRACE] [jsr223.jruby.log_test               ] - Test logging at trace
 logger.debug('Test logging at debug') # 2020-12-03 18:05:32.020 [DEBUG] [jsr223.jruby.log_test               ] - Test logging at debug
-logger.warn('Test logging at warn') # 2020-12-03 18:05:41.817 [WARN ] [jsr223.jruby.log_test               ] - Test logging at warn
-logger.info('Test logging at info') # Test logging at info
+logger.warn('Test logging at warn')   # 2020-12-03 18:05:41.817 [WARN ] [jsr223.jruby.log_test               ] - Test logging at warn
+logger.info('Test logging at info')   # 2020-12-03 18:05:42.215 [WARN ] [jsr223.jruby.log_test               ] - Test logging at info
 logger.error('Test logging at error') # 2020-12-03 18:06:02.021 [ERROR] [jsr223.jruby.log_test               ] - Test logging at error
 ```
 
+When called from within a rule, the name of the rule will be used instead of the file name.
+
+```ruby
+rule 'my rule' do
+  on_start
+  run { logger.info('Hello World!') } # 08:48:45.192 [INFO ] [jsr223.jruby.my_rule                 ] - Hello World!
+end
+```
+
+A custom suffix can be supplied as an argument to logger.
+
+```ruby
+logger('my_custom_logging').info('Hello World!') # 08:52:14.185 [INFO ] [jsr223.jruby.my_custom_logging       ] - Hello World!
+```
+
+To use the custom suffix multiple times:
+
+```ruby
+log = logger('my_custom_logging')
+log.info('Hi')
+log.info('Hi Again!')
+```

--- a/features/logging.feature
+++ b/features/logging.feature
@@ -11,9 +11,7 @@ Feature:  logging
       logger.send('<level>'.downcase, 'Test logging at <level>')
       """
     When I deploy the rules file named "log_test.rb"
-    Then It should log 'Test logging at <level>' within 5 seconds
-    # Waiting on merge for regex test PR
-    # Then It should log /\[<level>\].*Test logging at <level>/ within 5 seconds
+    Then It should log /\[<level>\s*\].*Test logging at <level>/ within 5 seconds
     Examples:
       | level |
       | TRACE |
@@ -34,17 +32,32 @@ Feature:  logging
   Scenario: Logging outputs file as part of log path
     Given code in a rules file
       """
-      # Log at a level
-      logger.info("Test logging at for #{__FILE__}")
-
-      rule 'log rule' do
-        on_start
-        run { logger.info('Log Test') }
-      end
-
+      # Log at file level
+      logger.info("Test logging at file level for #{__FILE__}")
       """
     When I deploy the rules file named "log_test.rb"
-    Then It should log 'jsr223.jruby.log_test' within 5 seconds
+    Then It should log /\[jsr223\.jruby\.log_test\s*\]/ within 5 seconds
+
+  Scenario: Logging within a top-level timer outputs file as part of log path
+    Given code in a rules file
+      """
+      after(5.ms) { logger.info("Plain logging inside a timer") }
+      """
+    When I deploy the rules file named "timer_test.rb"
+    Then It should log /\[jsr223.jruby.timer_test\s*\]/ within 5 seconds
+
+  Scenario: Logging within a timer inside a rule outputs file as part of log path
+    Given code in a rules file
+      """
+      rule 'a rule' do
+        on_start
+        run do
+          after(5.ms) { logger.info("Plain logging inside a timer inside a rule") }
+        end
+      end
+      """
+    When I deploy the rules file named "timer_inside_rule.rb"
+    Then It should log /\[jsr223.jruby.timer_inside_rule\s*\]/ within 5 seconds
 
   Scenario Outline: Logging should include rule name inside a rule
     Given items:
@@ -54,48 +67,81 @@ Feature:  logging
       """
       rule 'rule 1' do
         <trigger1>
-        run { logger.info('1 <trigger1>') }
+        run {     logger.info('rule 1 <trigger1>') }
       end
       rule 'rule 2' do
         <trigger1>
-        run { logger.info('2 <trigger1>') }
+        run {     logger.info('rule 2 <trigger1>') }
       end
       rule 'rule 3' do
         <trigger2>
-        run { logger.info('3 <trigger2>') }
+        run {     logger.info('rule 3 <trigger2>') }
       end
       rule 'rule 4' do
         <trigger2>
-        run { logger.info('4 <trigger2>') }
+        run {     logger.info('rule 4 <trigger2>') }
       end
       """
-    When I deploy the rule
+    When I deploy the rules file named "rule_file.rb"
     And item "Switch1" state is changed to "ON"
-    Then It should log "[jsr223.jruby.rule_1                 ] - 1 <trigger1>" within 5 seconds
-    And  It should log "[jsr223.jruby.rule_2                 ] - 2 <trigger1>" within 5 seconds
-    And  It should log "[jsr223.jruby.rule_3                 ] - 3 <trigger2>" within 5 seconds
-    And  It should log "[jsr223.jruby.rule_4                 ] - 4 <trigger2>" within 5 seconds
+    Then It should log /\[jsr223.jruby.rule_file.rule_1\s*\] - rule 1 <trigger1>/ within 5 seconds
+    And  It should log /\[jsr223.jruby.rule_file.rule_2\s*\] - rule 2 <trigger1>/ within 5 seconds
+    And  It should log /\[jsr223.jruby.rule_file.rule_3\s*\] - rule 3 <trigger2>/ within 5 seconds
+    And  It should log /\[jsr223.jruby.rule_file.rule_4\s*\] - rule 4 <trigger2>/ within 5 seconds
     Examples:
       | trigger1                 | trigger2                 |
       | on_start                 | received_command Switch1 |
       | received_command Switch1 | on_start                 |
 
-  Scenario Outline: Logging should include rule name inside a timer
+  Scenario Outline: Logging should include rule name inside a guard
     Given items:
       | type   | name    |
       | Switch | Switch1 |
     And a rule:
       """
-      rule 'on start' do
-        on_start
-        run { after(1.second) { logger.info('inside on_start timer') } }
+      rule 'rule 1' do
+        <trigger1>
+        only_if { logger.info('guard 1 <trigger1>'); true }
+        run {     logger.info('rule  1 <trigger1>') }
       end
-      rule 'trigger' do
-        received_command Switch1
-        run { after(1.second) { logger('timer_for_trigger').info('inside received_command timer') } }
+      rule 'rule 2' do
+        <trigger1>
+        only_if { logger.info('guard 2 <trigger1>'); true }
+        run {     logger.info('rule  2 <trigger1>') }
+      end
+      rule 'rule 3' do
+        <trigger2>
+        only_if { logger.info('guard 3 <trigger2>'); true }
+        run {     logger.info('rule  3 <trigger2>') }
+      end
+      rule 'rule 4' do
+        <trigger2>
+        only_if { logger.info('guard 4 <trigger2>'); true }
+        run {     logger.info('rule  4 <trigger2>') }
       end
       """
-    When I deploy the rule
+    When I deploy the rules file named "rule_file.rb"
     And item "Switch1" state is changed to "ON"
-    Then It should log "[jsr223.jruby.__timer                ] - inside on_start timer" within 5 seconds
-    And  It should log "[jsr223.jruby.timer_for_trigger      ] - inside received_command timer" within 5 seconds
+    Then It should log /\[jsr223.jruby.rule_file.rule_1\s*\] - guard 1 <trigger1>/ within 5 seconds
+    And  It should log /\[jsr223.jruby.rule_file.rule_2\s*\] - guard 2 <trigger1>/ within 5 seconds
+    And  It should log /\[jsr223.jruby.rule_file.rule_3\s*\] - guard 3 <trigger2>/ within 5 seconds
+    And  It should log /\[jsr223.jruby.rule_file.rule_4\s*\] - guard 4 <trigger2>/ within 5 seconds
+    Examples:
+      | trigger1                 | trigger2                 |
+      | on_start                 | received_command Switch1 |
+      | received_command Switch1 | on_start                 |
+
+  Scenario: Logging can use a custom suffix
+    Given a rule:
+      """
+      rule 'on start' do
+        on_start
+        run { after(1.second) { logger('custom_log').info('inside on_start timer') } }
+      end
+
+      logger('custom_top').info('outside a rule')
+      """
+    When I deploy the rules file named "rule_file.rb"
+    And item "Switch1" state is changed to "ON"
+    Then It should log /\[jsr223.jruby.rule_file.custom_log\s*\] - inside on_start timer/ within 5 seconds
+    Then It should log /\[jsr223.jruby.rule_file.custom_top\s*\] - outside a rule/ within 5 seconds

--- a/lib/openhab.rb
+++ b/lib/openhab.rb
@@ -20,10 +20,8 @@ module OpenHAB
   #
   #
   # Number of extensions and includes requires more lines
-  # rubocop: disable Metrics/MethodLength
   def self.extended(base)
     OpenHAB::Core.wait_till_openhab_ready
-    base.extend Log
     base.extend OpenHAB::Core::ScriptHandling
     base.extend OpenHAB::Core::EntityLookup
     base.extend OpenHAB::DSL
@@ -36,7 +34,6 @@ module OpenHAB
 
     OpenHAB::Core.add_rubylib_to_load_path
   end
-  # rubocop: enable Metrics/MethodLength
 end
 
 # Extend caller with OpenHAB methods

--- a/lib/openhab/core/thread_local.rb
+++ b/lib/openhab/core/thread_local.rb
@@ -4,7 +4,7 @@
 module OpenHAB
   module Core
     #
-    # Manages thread local varaibles for access inside of blocks
+    # Manages thread local variables for access inside of blocks
     #
     module ThreadLocal
       #

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -60,7 +60,7 @@ module OpenHAB
         #
         # rubocop: disable Metrics/MethodLength
         def execute(mod = nil, inputs = nil)
-          thread_local(logger_name: logger_name) do
+          thread_local(logger_name: name) do
             logger.trace { "Execute called with mod (#{mod&.to_string}) and inputs (#{inputs&.pretty_inspect})" }
             logger.trace { "Event details #{inputs['event'].pretty_inspect}" } if inputs&.key?('event')
             if trigger_delay inputs
@@ -394,15 +394,6 @@ module OpenHAB
         def process_run_task(event, task)
           logger.trace { "Executing rule '#{name}' run block with event(#{event})" }
           @run_context.instance_exec(event, &task.block)
-        end
-
-        #
-        # Return a formatted logger name based on the rule name
-        #
-        # @return [String] logger name to use for this rule
-        #
-        def logger_name
-          name.chomp.gsub(/\s+/, '_')
         end
 
         #

--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -43,19 +43,6 @@ module OpenHAB
       end
 
       #
-      # Create a logger where name includes rule name if name is set
-      #
-      # @return [Log::Logger] Logger with name that appended with rule name if rule name is set
-      #
-      def logger
-        if @rule_name
-          Log.logger_for(@rule_name.chomp.gsub(/\s+/, '_'))
-        else
-          super
-        end
-      end
-
-      #
       # Cleanup rules in this script file
       #
       def self.cleanup_rules

--- a/lib/openhab/dsl/rules/rule_config.rb
+++ b/lib/openhab/dsl/rules/rule_config.rb
@@ -135,19 +135,6 @@ module OpenHAB
         end
 
         #
-        # Create a logger where name includes rule name if name is set
-        #
-        # @return [Log::Logger] Logger with name that appended with rule name if rule name is set
-        #
-        def logger
-          if name
-            Log.logger_for(name.chomp.gsub(/\s+/, '_'))
-          else
-            super
-          end
-        end
-
-        #
         # Inspect the config object
         #
         # @return [String] details of the config object

--- a/lib/openhab/dsl/timers.rb
+++ b/lib/openhab/dsl/timers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'timers/timer_impl'
 require_relative 'timers/timer'
 require_relative 'timers/manager'
 require_relative 'timers/reentrant_timer'

--- a/lib/openhab/dsl/timers.rb
+++ b/lib/openhab/dsl/timers.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'timers/timer_impl'
 require_relative 'timers/timer'
 require_relative 'timers/manager'
 require_relative 'timers/reentrant_timer'

--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -133,10 +133,14 @@ module OpenHAB
 
     #
     # Create a logger for the current class
+    # Use Thread local variable logger_name if available
     #
     # @return [Logger] for the current class
     #
     def logger
+      name = Thread.current[:logger_name]
+      return Log.logger_for(name) if name
+
       Log.logger(self.class)
     end
 

--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -137,11 +137,11 @@ module OpenHAB
     #
     # @return [Logger] for the current class
     #
-    def logger
-      name = Thread.current[:logger_name]
+    def logger(name = nil)
+      name ||= Thread.current[:logger_name]
       return Log.logger_for(name) if name
 
-      Log.logger(self.class)
+      Log.logger_for_class(self.class)
     end
 
     class << self
@@ -152,7 +152,7 @@ module OpenHAB
       #
       # @return [Logger] for the supplied name
       #
-      def logger(klass)
+      def logger_for_class(klass)
         if klass.respond_to?(:java_class) &&
            klass.java_class &&
            !klass.java_class.name.start_with?('org.jruby.Ruby')
@@ -163,26 +163,13 @@ module OpenHAB
       end
 
       #
-      # Configure a logger for the supplied class name
-      #
-      # @param [String] name to configure logger for
-      #
-      # @return [Logger] for the supplied classname
-      #
-      def logger_for(name)
-        configure_logger_for(name)
-      end
-
-      private
-
-      #
-      # Configure a logger for the supplied classname
+      # Configure a logger for the supplied name
       #
       # @param [String] classname to create logger for
       #
-      # @return [Logger] Logger for the supplied classname
+      # @return [Logger] Logger for the supplied name
       #
-      def configure_logger_for(name)
+      def logger_for(name)
         log_prefix = Configuration.log_prefix
         log_prefix += if name
                         ".#{name}"
@@ -192,12 +179,15 @@ module OpenHAB
         Logger.new(log_prefix)
       end
 
+      private
+
       #
       # Figure out the log prefix
       #
       # @return [String] Prefix for log messages
       #
       def log_caller
+        logger.error('LOGGING: log_caller called')
         caller_locations.map(&:path)
                         .grep_v(%r{openhab/core/})
                         .grep_v(/rubygems/)
@@ -216,7 +206,7 @@ module OpenHAB
     def self.included(base)
       class << base
         def logger
-          Log.logger(self)
+          Log.logger_for_class(self)
         end
       end
     end


### PR DESCRIPTION
Fix #84 

- Logging at the top level will use the file name as the logger suffix as originally specified in the docs
- Logging inside a timer will use the same suffix as the top level logging, i.e. it will use the file name as the suffix
- The rule name will be used as the logger suffix when called inside a rule
- A custom suffix can be specified through `logger('custom suffix').<level>` 
- Clean up of redundant logger methods

