### PR TITLE
add things.by_channel lookup and item.thing helper

### DIFF
--- a/features/items.feature
+++ b/features/items.feature
@@ -225,3 +225,32 @@ Feature:  items
       | Number | Number1 |
       | String | String1 |
       | Player | Player1 |
+
+  Scenario: Item returns nil for thing for item without a channel
+    Given items:
+      | type | name |
+      | Number | Number1 |
+    And code in a rules file
+      """
+      logger.info("Thing: #{Number1.thing}")
+      """
+    When I deploy the rules file
+    Then It should log "Thing: " within 5 seconds
+
+  Scenario: Item returns its associated thing for item with a channel
+    Given feature 'openhab-binding-astro' installed
+    And items:
+      | type | name |
+      | String | PhaseName |
+    And things:
+      | id   | thing_uid | label          | config                | status |
+      | home | astro:sun | Astro Sun Data | {"geolocation":"0,0"} | enable |
+    And linked:
+      | item | channel |
+      | PhaseName | astro:sun:home:phase#name |
+    And code in a rules file
+      """
+      logger.info("Thing: #{PhaseName.thing.uid}")
+      """
+    When I deploy the rules file
+    Then It should log "Thing: astro:sun:home" within 5 seconds

--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -92,6 +92,12 @@ Given(/(?: I add)?items:/) do |table|
   end
 end
 
+Given('linked:') do |table|
+  table.hashes.each do |row|
+    link_item(item_name: row['item'], channel_uid: row['channel'])
+  end
+end
+
 Given('things:') do |table|
   table.hashes.each do |row|
     id = row['id']

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -124,6 +124,10 @@ def add_item(item:)
   Rest.add_item(item: item)
 end
 
+def link_item(item_name:, channel_uid:)
+  Rest.link_item(item_name: item_name, channel_uid: channel_uid)
+end
+
 def truncate_log
   File.open(openhab_log, File::TRUNC)
 end

--- a/features/support/openhab_rest.rb
+++ b/features/support/openhab_rest.rb
@@ -107,4 +107,12 @@ class Rest
     body[:groupNames] = groups unless groups.empty?
     body[:groupType] = item.group_type unless item.group_type.to_s.empty?
   end
+
+  def self.link_item(item_name:, channel_uid:)
+    body = { itemName: item_name, channelUID: channel_uid }
+    escaped_channel_uid = URI.encode_www_form_component(channel_uid)
+    put("/rest/links/#{item_name}/#{escaped_channel_uid}", headers: json, body: body.to_json)
+    # For some reason linking via the api doesn't create the metadata, this ensures it exists
+    put("/rest/items/#{item_name}/metadata/channel", headers: json, body: {value: channel_uid}.to_json)
+  end
 end

--- a/features/thing.feature
+++ b/features/thing.feature
@@ -24,6 +24,22 @@ Feature:  thing
     When I deploy the rules file
     Then It should log 'Thing: astro:sun:home' within 5 seconds
 
+  Scenario: Things support by_channel lookup with string
+    Given code in a rules file
+      """
+      logger.info("Thing: #{things.by_channel('astro:sun:home:rise#start').uid}")
+      """
+    When I deploy the rules file
+    Then It should log 'Thing: astro:sun:home' within 5 seconds
+
+  Scenario: Things support by_channel lookup with a ChannelUID
+    Given code in a rules file
+      """
+      logger.info("Thing: #{things.by_channel(org.openhab.core.thing.ChannelUID.new('astro:sun:home:rise#start')).uid}")
+      """
+    When I deploy the rules file
+    Then It should log 'Thing: astro:sun:home' within 5 seconds
+
   Scenario Outline: Rule supports thing status changes for changed and updated
     Given a deployed rule:
       """

--- a/lib/openhab/dsl/items/generic_item.rb
+++ b/lib/openhab/dsl/items/generic_item.rb
@@ -131,6 +131,16 @@ module OpenHAB
           group_names.map { |name| Groups.groups[name] }
         end
 
+        # Return the item's thing if this item is associated with a thing
+        #
+        # @return [Thing] The thing associated with this item or nil
+        def thing
+          channel = meta['channel']&.value
+          return unless channel
+
+          things.by_channel(channel)
+        end
+
         #
         # Check equality without type conversion
         #

--- a/lib/openhab/dsl/things.rb
+++ b/lib/openhab/dsl/things.rb
@@ -96,6 +96,18 @@ module OpenHAB
         alias include? []
         alias key? []
 
+        # Gets a specific thing related to a channel in the format binding_id:type_id:thing_id:channel_id
+        # or by the ChannelUID object
+        # @return Thing specified by channel or nil if the thing does not exist in the thing registry
+        def by_channel(channel_uid)
+          channel_uid = org.openhab.core.thing.ChannelUID.new(channel_uid) if channel_uid.is_a?(String)
+          thing = $things.get(channel_uid.thing_uid) # rubocop: disable Style/GlobalVars
+          return unless thing
+
+          logger.trace("Retrieved Thing(#{thing}) from registry for channel uid: #{channel_uid}")
+          Thing.new(thing)
+        end
+
         # explicit conversion to array
         def to_a
           $things.getAll.map { |thing| Thing.new(thing) } # rubocop: disable Style/GlobalVars


### PR DESCRIPTION
This patchset adds the ability to lookup a thing given a Channel UID by adding a by_channel methods to things.  It also adds a helper method to GenericItem to get the Channel UID from the item's metadata, and then call things to find the Thing.

An example use case for this is when Thing configuration data contains information that would be useful in a rule.  As an example, given a unlock keycode id from a zwave lock device:

```ruby
lock_thing = lock_item.thing
keycode_owner_name = lock_thing.configuration.get("usercode_label_#{keycode_id}")
notify "#{lock_item.label} unlocked by user #{keycode_owner_name}'
```