### PR TITLE
ci(build): drop support for OpenHAB 3.0

### DIFF
--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -2,7 +2,7 @@
 
 require 'json'
 
-OPENHAB_VERSIONS = ['3.0.2', '3.1.0'].freeze
+OPENHAB_VERSIONS = ['3.1.0'].freeze
 
 # rubocop: disable Metrics/BlockLength
 # Disabled due to part of buid / potentially refactor into classes


### PR DESCRIPTION
Remove OpenHAB 3.0 from testing as discussed in #403 