### PR TITLE
fix(comparisons): === should perform an exact type match for case statements

### DIFF
--- a/features/between.feature
+++ b/features/between.feature
@@ -81,60 +81,61 @@ Feature: between
       | '<%=(Time.now + (5*60)).strftime('%H:%M:%S')%>'..'<%=(Time.now + (10*60)).strftime('%H:%M:%S')%>' | Time.now | should not |
 
 
-    Scenario Outline: Between supports Day of Month 
+  Scenario Outline: Between supports Day of Month
     Given a rule template:
       """
       require 'date'
       range = between <between>
-      in_range = range.include?(<compare>) 
+      in_range = range.include?(<compare>)
       logger.info("in range: #{in_range}")
       """
     When I deploy the rule
     Then It should log "in range: <result>" within 5 seconds
     Examples: Checks in range, before range and after range
-      | between                                                                                           | compare                                | result   |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>'        | Date.today                             | true     |
-      | '<%=(Date.today + 10 ).strftime('%m-%d')%>'..'<%=(Date.today + 20).strftime('%m-%d')%>'           | Date.today                             | false    |
-      | '<%=(Date.today - 20 ).strftime('%m-%d')%>'..'<%=(Date.today - 10).strftime('%m-%d')%>'           | Date.today                             | false    |
+      | between                                                                                    | compare    | result |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>' | Date.today | true   |
+      | '<%=(Date.today + 10 ).strftime('%m-%d')%>'..'<%=(Date.today + 20).strftime('%m-%d')%>'    | Date.today | false  |
+      | '<%=(Date.today - 20 ).strftime('%m-%d')%>'..'<%=(Date.today - 10).strftime('%m-%d')%>'    | Date.today | false  |
 
 
-    Scenario Outline: Day of Month between ranges support multiple compare types
+  Scenario Outline: Day of Month between ranges support multiple compare types
     Given a rule template:
       """
       require 'date'
       range = between <between>
-      in_range = range.include?(<compare>) 
+      in_range = range.include?(<compare>)
       logger.info("in range: #{in_range}")
       """
     When I deploy the rule
     Then It should log "in range: <result>" within 5 seconds
     Examples: Checks Date, Time, and DateTime
-      | between                                                                                           | compare       | result   |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>'        | Date.today    | true     |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>'        | Time.now      | true     |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>'        | DateTime.now  | true     |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>'        | MonthDay.now  | true     |
+      | between                                                                                    | compare      | result |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>' | Date.today   | true   |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>' | Time.now     | true   |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>' | DateTime.now | true   |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>' | MonthDay.now | true   |
 
-    Scenario Outline: Between supports strings and MonthDay objects for ranges
+  Scenario Outline: Between supports strings and MonthDay objects for ranges
     Given a rule template:
       """
       require 'date'
       require 'java'
       java_import java.time.LocalDate
       today = LocalDate.now
-      dom = today.get_day_of_month
-      yesterday = MonthDay.of(today.get_month_value, dom -1)
-      tomorrow = MonthDay.of(today.get_month_value, dom +1)
+      date_yesterday = today.minus_days(1)
+      date_tomorrow = today.plus_days(1)
+      yesterday = MonthDay.of(date_yesterday.month_value, date_yesterday.day_of_month)
+      tomorrow = MonthDay.of(date_tomorrow.month_value, date_tomorrow.day_of_month)
       range = between <between>
-      in_range = range.include?(<compare>) 
+      in_range = range.include?(<compare>)
       logger.info("in range: #{in_range}")
       """
     When I deploy the rule
     Then It should log "in range: <result>" within 5 seconds
     Examples: Checks in range, before range and after range
-      | between                                                                                           | compare      | result   |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>'        | Date.today   | true     |
-      | yesterday..tomorrow                                                                               | Date.today   | true     |
-      | yesterday..'<%=Date.today.next_day.strftime('%m-%d')%>'                                           | Date.today   | true     |
-      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..tomorrow                                            | Date.today   | true     |
+      | between                                                                                    | compare    | result |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..'<%=Date.today.next_day.strftime('%m-%d')%>' | Date.today | true   |
+      | yesterday..tomorrow                                                                        | Date.today | true   |
+      | yesterday..'<%=Date.today.next_day.strftime('%m-%d')%>'                                    | Date.today | true   |
+      | '<%=Date.today.prev_day.strftime('%m-%d')%>'..tomorrow                                     | Date.today | true   |
 

--- a/features/comparisons.feature
+++ b/features/comparisons.feature
@@ -13,29 +13,29 @@ Feature: comparisons
       | ShuttersPos  | Rollershutter      | MAX      |              |
 
     And items:
-      | type               | name            | label                   | groups                | state                     |
-      | Number             | Number5         | Number Five             |                       | 5                         |
-      | Number             | Number10        | Number Ten              |                       | 10                        |
-      | Number             | Number10A       | Number Ten A            |                       | 10                        |
-      | Number             | Number20        | Number Twenty           |                       | 20                        |
-      | Number             | NumberNull      | Number NULL             |                       | NULL                      |
-      | Number             | NumberNullA     | Number NULL A           |                       | NULL                      |
-      | Number:Temperature | Number5C        | Number Five             | Temperatures          | 5°C                       |
-      | Number:Temperature | Number10C       | Number Ten              | Temperatures          | 10°C                      |
-      | Number:Temperature | Number10C2      | Number Ten              | Temperatures          | 10°C                      |
-      | Number:Temperature | Number20C       | Number Twenty           | Temperatures          | 20°C                      |
-      | Number:Illuminance | NumberLux       | Number Lux              |                       | 465.3 lx                  |
-      | Dimmer             | Dimmer5         | Dimmer Five             |                       | 5                         |
-      | Dimmer             | Dimmer10        | Dimmer Ten              |                       | 10                        |
-      | Switch             | SwitchOne       | Switch One              | Switches              | ON                        |
-      | Switch             | SwitchTwo       | Switch Two              | Switches              | OFF                       |
-      | Contact            | ContactOne      | Contact One             | Contacts              | OPEN                      |
-      | Contact            | ContactTwo      | Contact Two             | Contacts              | CLOSED                    |
-      | DateTime           | DateOne         | Date One                | Dates                 | 2021-01-01T00:00:00+00:00 |
-      | DateTime           | DateTwo         | Date Two                | Dates                 | 2021-02-01T12:00:00+00:00 |
-      | Rollershutter      | ShutterOne      | Shutter One             | Shutters, ShuttersPos | 0                         |
-      | Rollershutter      | ShutterTwo      | Shutter Two             | Shutters, ShuttersPos | 50                        |
-      | Color              | Color           | Color                   |                       | 0, 100, 100               |
+      | type               | name        | label         | groups                | state                     |
+      | Number             | Number5     | Number Five   |                       | 5                         |
+      | Number             | Number10    | Number Ten    |                       | 10                        |
+      | Number             | Number10A   | Number Ten A  |                       | 10                        |
+      | Number             | Number20    | Number Twenty |                       | 20                        |
+      | Number             | NumberNull  | Number NULL   |                       | NULL                      |
+      | Number             | NumberNullA | Number NULL A |                       | NULL                      |
+      | Number:Temperature | Number5C    | Number Five   | Temperatures          | 5°C                       |
+      | Number:Temperature | Number10C   | Number Ten    | Temperatures          | 10°C                      |
+      | Number:Temperature | Number10C2  | Number Ten    | Temperatures          | 10°C                      |
+      | Number:Temperature | Number20C   | Number Twenty | Temperatures          | 20°C                      |
+      | Number:Illuminance | NumberLux   | Number Lux    |                       | 465.3 lx                  |
+      | Dimmer             | Dimmer5     | Dimmer Five   |                       | 5                         |
+      | Dimmer             | Dimmer10    | Dimmer Ten    |                       | 10                        |
+      | Switch             | SwitchOne   | Switch One    | Switches              | ON                        |
+      | Switch             | SwitchTwo   | Switch Two    | Switches              | OFF                       |
+      | Contact            | ContactOne  | Contact One   | Contacts              | OPEN                      |
+      | Contact            | ContactTwo  | Contact Two   | Contacts              | CLOSED                    |
+      | DateTime           | DateOne     | Date One      | Dates                 | 2021-01-01T00:00:00+00:00 |
+      | DateTime           | DateTwo     | Date Two      | Dates                 | 2021-02-01T12:00:00+00:00 |
+      | Rollershutter      | ShutterOne  | Shutter One   | Shutters, ShuttersPos | 0                         |
+      | Rollershutter      | ShutterTwo  | Shutter Two   | Shutters, ShuttersPos | 50                        |
+      | Color              | Color       | Color         |                       | 0, 100, 100               |
 
   Scenario: Comparisons can be done against different types
     Given code in a rules file
@@ -70,7 +70,7 @@ Feature: comparisons
         [ Number10                    , '<'   , DecimalType.new(20)         , true  ]  ,
         [ Number10                    , '<'   , DecimalType.new(5)          , false ]  ,
         [ Number10                    , '>'   , DecimalType.new(5)          , true  ]  ,
-        [ Number10                    , '>'   , DecimalType.new(20)         , false ]  ,        
+        [ Number10                    , '>'   , DecimalType.new(20)         , false ]  ,
 
         # NumberItem vs Ruby Numeric
         [ Number10                    , 'eql?', 10                          , false ]  ,
@@ -541,7 +541,6 @@ Feature: comparisons
 
         [ (0..100)                    , '===' , ON                          , false ]  ,
         [ 50                          , '=='  , ON                          , false ]  ,
-        [ ON                          , '===' , PercentType.new(50)         , true  ]  ,
       ]
 
       def test_to_s(test)

--- a/features/dimmer_item.feature
+++ b/features/dimmer_item.feature
@@ -175,30 +175,3 @@ Feature:  dimmer_item
     And It should log "DimmerOne == 50? true" within 5 seconds
     And It should log "DimmerOne < 60? true" within 5 seconds
     And It should log "DimmerOne == DimmerTwo? true" within 5 seconds
-
-  Scenario Outline: Handle Numeric and OnOffType command in a case
-    Given code in a rules file
-      """
-      rule 'commanded' do
-        received_command DimmerOne
-        run do |event|
-          case event.command
-          when 0..49 then logger.info("up to 49%")
-          when 51..100 then logger.info("greater than 50%")
-          when 50 then logger.info("Exactly 50%")
-          when ON then logger.info("It is ON")
-          when OFF then logger.info("It is OFF")
-          end
-        end
-      end
-      DimmerOne << <state>
-      """
-    When I deploy the rules file
-    Then It should log "<log>" within 5 seconds
-    Examples:
-      | state | log              |
-      | ON    | It is ON         |
-      | OFF   | It is OFF        |
-      | "10"  | up to 49%        |
-      | "50"  | Exactly 50%      |
-      | "100" | greater than 50% |

--- a/features/groups.feature
+++ b/features/groups.feature
@@ -125,10 +125,10 @@ Feature:  groups
 
   Scenario: Groups work in case statements
     Given groups:
-      | name         | type          | function | params       |
-      | Switches     | Switch        | AND      | ON, OFF      |
-      | Contacts     | Contact       | OR       | OPEN, CLOSED |
-      | Shutters     | Rollershutter | AND      | UP, DOWN     |
+      | name     | type          | function | params       |
+      | Switches | Switch        | AND      | ON, OFF      |
+      | Contacts | Contact       | OR       | OPEN, CLOSED |
+      | Shutters | Rollershutter | AND      | UP, DOWN     |
 
     And items:
       | type          | name       | label       | state  | groups   |
@@ -152,8 +152,8 @@ Feature:  groups
       end
 
       case Shutters
-      when UP then logger.info('All shutters are UP')
-      when DOWN then logger.info('At least one shutter is not UP')
+      when 0 then logger.info('All shutters are UP')
+      when 100 then logger.info('At least one shutter is not UP')
       end
       """
     When I deploy the rules file
@@ -222,7 +222,7 @@ Feature:  groups
       | name     | type    |
       | Switches | Contact |
     Then It should log "false" within 10 seconds
-  
+
   Scenario: Can add lazy arrays together
     Given code in a rules file
       """

--- a/features/rollershutter_item.feature
+++ b/features/rollershutter_item.feature
@@ -95,8 +95,8 @@ Feature: rollershutter_item
     And code in a rules file
       """
       case RollerOne
-      when UP then logger.info('RollerOne is UP')
-      when DOWN then logger.info('RollerOne is DOWN')
+      when 0 then logger.info('RollerOne is UP')
+      when 100 then logger.info('RollerOne is DOWN')
       when (51...100) then logger.info('RollerOne is in range 51...100')
       when (1..50) then logger.info('RollerOne is in range 1..50')
       else

--- a/lib/openhab/dsl/types/type.rb
+++ b/lib/openhab/dsl/types/type.rb
@@ -42,6 +42,20 @@ module OpenHAB
         end
 
         #
+        # Case equality
+        #
+        # @return [Boolean] if the values are of the same Type
+        #                   or item state of the same type
+        #
+        def ===(other)
+          logger.trace("(#{self.class}) #{self} === #{other} (#{other.class})")
+          other = other.state if other.respond_to?(:state)
+          return false unless instance_of?(other.class)
+
+          eql?(other)
+        end
+
+        #
         # Check equality, including type conversion
         #
         # @return [Boolean] if the same value is represented, including


### PR DESCRIPTION
Resolve #365 

**This could potentially be a breaking change.**

`case` comparisons must now use the underlying type.

Case in point:
```ruby
RollerShutterItem1 << DOWN
case RollerShutterItem1
when DOWN then logger.info("It will no longer reach here")
when 100 then logger.info("It will reach here: 100")
end
```

I believe this is the correct / non ambiguous behaviour. It also allows precision handling of commands sent to items that support multiple types, which is the whole reason for this PR.

Example:
```ruby
rule 'x' do
  received_command RollerShutterItem1
  run do |event|
    case event.command
    when 0..100 then logger.info("A specific position has been commanded")
    when DOWN then logger.info("DOWN command received")
    end
  end
end

RollerShutterItem1 << DOWN
```

The following will still evaluate to true, as it's not affected by this PR: `RollerShutterItem1 == 100`, `RollerShutterItem1 == DOWN` or `RollerShutterItem1.down?`