### PR TITLE
refactor(quantity_type): remove | method and alias it to to_unit

### DIFF
--- a/features/quantity_type.feature
+++ b/features/quantity_type.feature
@@ -12,10 +12,10 @@ Feature:  quantity_type
     When I deploy the rules file
     Then It should log 'Result is <result>' within 5 seconds
     Examples:
-      | quantity         | result   |
-      | 50 \| '°F'       | 50.0 °F  |
-      | 50.0 \| '°F'     | 50.0 °F  |
-      | 50.to_d \| '°F'  | 50.0 °F  |
+      | quantity       | result  |
+      | 50 \|'°F'      | 50.0 °F |
+      | 50.0 \|'°F'    | 50.0 °F |
+      | 50.to_d \|'°F' | 50.0 °F |
 
   Scenario Outline: QuantityType is constructuble with | from numeric from within rule
     Given items:
@@ -63,9 +63,9 @@ Feature:  quantity_type
     When I deploy the rules file
     Then It should log 'Result is <result>' within 5 seconds
     Examples:
-      | quantity                   | operator | operand | result   |
-      | QuantityType.new('50 °F')  | +        | '50 °F' | 100.0 °F |
-      | QuantityType.new('50 °F')  | -        | '25 °F' | 25.0 °F  |
+      | quantity                  | operator | operand | result   |
+      | QuantityType.new('50 °F') | +        | '50 °F' | 100.0 °F |
+      | QuantityType.new('50 °F') | -        | '25 °F' | 25.0 °F  |
 
 
   Scenario Outline: QuantityType responds to math operations where operand is Numeric
@@ -177,3 +177,17 @@ Feature:  quantity_type
       | PowerNeg                  | negative? | true   |
       | PowerZero                 | zero?     | true   |
       | Number1                   | positive? | true   |
+
+  Scenario Outline: QuantityType can be converted to another unit with |
+    Given code in a rules file
+      """
+      quantity = <source>|'<unit1>'
+      quantity = quantity|'<unit2>'
+      logger.info("quantity in the target unit is #{quantity.to_i}")
+      """
+    When I deploy the rules file
+    Then It should log "quantity in the target unit is <target>" within 5 seconds
+    Examples:
+      | source | unit1 | unit2 | target |
+      | 0      | °C    | °F    | 32     |
+      | 1      | h     | s     | 3600   |

--- a/lib/openhab/dsl/types/quantity_type.rb
+++ b/lib/openhab/dsl/types/quantity_type.rb
@@ -30,11 +30,7 @@ module OpenHAB
         #
         # @return [QuantityType] This quantity converted to another unit
         #
-        def |(other)
-          other = org.openhab.core.types.util.UnitUtils.parse_unit(other) if other.is_a?(String)
-
-          to_unit(other)
-        end
+        alias | to_unit
 
         #
         # Comparison


### PR DESCRIPTION
The `#|` method is redundant. String argument is already implemented in openhab-core 

https://github.com/openhab/openhab-core/blob/598245b9197a26d1e4a64748cbd211a8fe8ff0c8/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java#L277-L284

