### PR TITLE
feat(timers): support passing `NumberItem` as timer duration

### DIFF
--- a/docs/usage/misc/timers.md
+++ b/docs/usage/misc/timers.md
@@ -44,6 +44,15 @@ end
 ```
 
 ```ruby
+# An item can be the duration for a timer, the value will be interpreted as seconds
+MyNumericItem << 3
+
+after MyNumericItem do
+  logger.info("Timer Fired after 3 seconds")
+end
+```
+
+```ruby
 # Timers delegate methods to OpenHAB timer objects
 after 1.second do |timer|
   logger.info("Timer is active? #{timer.is_active}")
@@ -63,6 +72,20 @@ end
 after 3.seconds do |timer|
   logger.info("Timer Fired")
   timer.reschedule 5.seconds
+end
+```
+
+```ruby
+# If the duration is an item, it will be reevaluated on reschedule
+MyNumericItem << 3
+
+after MyNumericItem do |timer|
+  logger.info("Timer Fired after 3 seconds")
+
+  MyNumericItem << 6 # could be changed anywhere, not only in timer's block
+
+  # rescheduled timer will fire after 6 seconds
+  timer.reschedule
 end
 ```
 

--- a/docs/usage/triggers/changed.md
+++ b/docs/usage/triggers/changed.md
@@ -32,6 +32,16 @@ rule "Execute rule when item is changed for specified duration" do
 end
 ```
 
+For parameter can be an item, too:
+```ruby
+Alarm_Delay << 20
+
+rule "Execute rule when item is changed for specified duration" do
+  changed Alarm_Mode, for: Alarm_Delay
+  run { logger.info("Alarm Mode Updated")}
+end
+```
+
 You can optionally provide from and to states to restrict the cases in which the rule executes:
 ```ruby
 rule 'Execute rule when item is changed to specific number, from specific number, for specified duration' do

--- a/features/changed_duration.feature
+++ b/features/changed_duration.feature
@@ -6,8 +6,9 @@ Feature: changed_duration
 
   Scenario Outline: Changed item supports duration and/or to and/or from.
     Given items:
-      | type   | name       | label      | state  |
-      | Number | Alarm_Mode | Alarm Mode | <from> |
+      | type   | name        | label        | state  |
+      | Number | Alarm_Mode  | Alarm Mode   | <from> |
+      | Number | Alarm_Delay | Alarm Delay  | 10     |
     And a rule
       """
       rule 'Execute rule when item is changed to specific number for specified duration' do
@@ -24,6 +25,7 @@ Feature: changed_duration
     Examples: Checks multiple from and to states
       | from | to | rule                                                             | should     |
       | 8    | 14 | changed Alarm_Mode, for: 10.seconds                              | should     |
+      | 8    | 14 | changed Alarm_Mode, for: Alarm_Delay                             | should     |
       | 8    | 14 | changed Alarm_Mode, to: 14, for: 10.seconds                      | should     |
       | 8    | 10 | changed Alarm_Mode, to: 14, for: 10.seconds                      | should not |
       | 8    | 14 | changed Alarm_Mode, from: 8, to: 14, for: 10.seconds             | should     |
@@ -33,7 +35,6 @@ Feature: changed_duration
       | 8    | 14 | changed Alarm_Mode, from: [8, 10], to: [11, 14], for: 10.seconds | should     |
       | 8    | 12 | changed Alarm_Mode, from: [8, 10], to: [11, 14], for: 10.seconds | should not |
       | 8    | 14 | changed Alarm_Mode, from: [9, 10], to: [11, 14], for: 10.seconds | should not |
-
 
   Scenario: Changed item has duration specified and is modified during that duration
     Given items:

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -28,6 +28,47 @@ Feature:  timer
     But if I wait 3 seconds
     Then It should log 'Timer Fired' within 5 seconds
 
+  Scenario: Timers support number items
+    Given items:
+      | type   | name       | label      | state   |
+      | Number | Alarm_Time | Alarm Mode | <state> |
+    And code in a rules file
+      """
+      after Alarm_Time do
+        logger.info("Timer Fired")
+      end
+      """
+    When I deploy the rules file
+    Then It should not log 'Timer Fired' within 4 seconds
+    Then It should log 'Timer Fired' within 3 seconds
+
+    Examples: Works with different numbers
+      | state |
+      | 5     |
+      | 5.5   |
+
+  Scenario: Timers support custom user provided objects
+    Given code in a rules file
+      """
+      value = Module.new do
+        def self.<method>
+          5
+        end
+      end
+
+      after value do
+        logger.info("Timer Fired")
+      end
+      """
+    When I deploy the rules file
+    Then It should not log 'Timer Fired' within 4 seconds
+    Then It should log 'Timer Fired' within 3 seconds
+
+    Examples: Works with different accessors
+      | method |
+      | to_f   |
+      | to_i   |
+
   Scenario: Timers support 'active?', 'running?' and 'terminated?'
     Given code in a rules file
       """


### PR DESCRIPTION
item's state is evaluated as number of seconds for timer. Eg with a
`Alarm_Delay` `NumberItem` this is now possible:

```rb
after Alarm_Delay { ... }

changed Alarm_Mode, for: Alarm_Delay
```

when rescheduling, the item's state will be revaluated.