### PR TITLE
feat(channel_trigger): allow setting channel triggers directly from channel/thing objects

### DIFF
--- a/docs/usage/things.md
+++ b/docs/usage/things.md
@@ -19,10 +19,12 @@ Things can be access using the `things` method and subsequent operations on that
 
 ```ruby
 things.each { |thing| logger.info("Thing: #{thing.uid}")}
-```
-
-```ruby
 logger.info("Thing: #{things['astro:sun:home'].uid}")
+homie_things = things.select { |t| t.thing_type_uid == "mqtt:homie300" }
+zwave_things = things.select { |t| t.binding_id == "zwave" }
+homeseer_dimmers = zwave_things.select { |t| t.thing_type_uid.id == "homeseer_hswd200_00_000" }
+things['zwave:device:512:node90'].uid.bridge_ids => ["512"]
+things['mqtt:topic:4'].uid.bridge_ids => []
 ```
 
 ## Thing objects

--- a/docs/usage/triggers/channel.md
+++ b/docs/usage/triggers/channel.md
@@ -23,13 +23,37 @@ rule 'Execute rule when channel is triggered' do
   run { logger.info("Channel triggered") }
 end
 
-# The above is the same as the below
+# The above is the same as each of the below
 
 rule 'Execute rule when channel is triggered' do
   channel 'rise#event', thing: 'astro:sun:home'   
   run { logger.info("Channel triggered") }
 end
 
+rule 'Execute rule when channel is triggered' do
+  channel 'rise#event', thing: things['astro:sun:home']
+  run { logger.info("Channel triggered") }
+end
+
+rule 'Execute rule when channel is triggered' do
+  channel 'rise#event', thing: things['astro:sun:home'].uid
+  run { logger.info("Channel triggered") }
+end
+
+rule 'Execute rule when channel is triggered' do
+  channel 'rise#event', thing: ['astro:sun:home']
+  run { logger.info("Channel triggered") }
+end
+
+rule 'Execute rule when channel is triggered' do
+  channel things['astro:sun:home'].channels['rise#event']
+  run { logger.info("Channel triggered") }
+end
+
+rule 'Execute rule when channel is triggered' do
+  channel things['astro:sun:home'].channels['rise#event'].uid
+  run { logger.info("Channel triggered") }
+end
 ```
 
 ```ruby
@@ -49,6 +73,13 @@ end
 ```ruby
 rule 'Rules support multiple channels and triggers' do
   channel ['rise#event','set#event'], thing: 'astro:sun:home', triggered: ['START', 'STOP'] 
+  run { logger.info("Channel triggered") }
+end
+```
+
+```ruby
+rule 'Rules support multiple things' do
+  channel 'keypad#code', thing: ['mqtt:homie300:keypad1', 'mqtt:homie300:keypad1']
   run { logger.info("Channel triggered") }
 end
 ```

--- a/features/channels.feature
+++ b/features/channels.feature
@@ -3,6 +3,10 @@ Feature:  channels
 
   Background:
     Given Clean OpenHAB with latest Ruby Libraries
+    And feature 'openhab-binding-astro' installed
+    And things:
+      | id   | thing_uid | label          | config                | status |
+      | home | astro:sun | Astro Sun Data | {"geolocation":"0,0"} | enable |
 
   Scenario Outline: Rule supports channel triggers
     Given a deployed rule:
@@ -15,9 +19,17 @@ Feature:  channels
     When channel "<channel>" is triggered
     Then It should log 'Channel triggered' within 5 seconds
     Examples: Checks support for string based and thing based channels
-      | trigger                                       | channel                   |
-      | channel 'astro:sun:home:rise#event'           | astro:sun:home:rise#event |
-      | channel 'rise#event', thing: 'astro:sun:home' | astro:sun:home:rise#event |
+      | trigger                                                       | channel                   |
+      | channel 'astro:sun:home:rise#event'                           | astro:sun:home:rise#event |
+      | channel 'rise#event', thing: 'astro:sun:home'                 | astro:sun:home:rise#event |
+      | channel 'rise#event', thing: things['astro:sun:home']         | astro:sun:home:rise#event |
+      | channel 'rise#event', thing: things['astro:sun:home'].uid     | astro:sun:home:rise#event |
+      | channel 'rise#event', thing: [things['astro:sun:home']]       | astro:sun:home:rise#event |
+      | channel 'rise#event', thing: [things['astro:sun:home'].uid]   | astro:sun:home:rise#event |
+      | channel things['astro:sun:home'].channels['rise#event']       | astro:sun:home:rise#event |
+      | channel things['astro:sun:home'].channels['rise#event'].uid   | astro:sun:home:rise#event |
+      | channel [things['astro:sun:home'].channels['rise#event']]     | astro:sun:home:rise#event |
+      | channel [things['astro:sun:home'].channels['rise#event'].uid] | astro:sun:home:rise#event |
 
 
   Scenario: Rule provides access channel trigger events in run block

--- a/features/thing.feature
+++ b/features/thing.feature
@@ -32,6 +32,38 @@ Feature:  thing
     When I deploy the rules file
     Then It should log 'Thing: astro:sun:home' within 5 seconds
 
+  Scenario: ThingUID#inspect logs the full UID as string
+    Given code in a rules file
+      """
+      logger.info("Thing: #{org.openhab.core.thing.ThingUID.new('astro:sun:home').inspect}")
+      """
+    When I deploy the rules file
+    Then It should log 'Thing: astro:sun:home' within 5 seconds
+
+  Scenario: ThingUID#== works against a regular string
+    Given code in a rules file
+      """
+      logger.info("Is equal: #{org.openhab.core.thing.ThingUID.new('astro:sun:home') == 'astro:sun:home'}")
+      """
+    When I deploy the rules file
+    Then It should log 'Is equal: true' within 5 seconds
+
+  Scenario: String#== works against a ThingUID (using ThingUID#to_str)
+    Given code in a rules file
+      """
+      logger.info("Is equal: #{'astro:sun:home' == org.openhab.core.thing.ThingUID.new('astro:sun:home')}")
+      """
+    When I deploy the rules file
+    Then It should log 'Is equal: true' within 5 seconds
+
+  Scenario: ThingUID#binding_id returns the correct value
+    Given code in a rules file
+      """
+      logger.info("Binding: #{org.openhab.core.thing.ThingUID.new('astro:sun:home').binding_id}$")
+      """
+    When I deploy the rules file
+    Then It should log 'Binding: astro$' within 5 seconds
+
   Scenario Outline: Rule supports thing status changes for changed and updated
     Given a deployed rule:
       """

--- a/lib/openhab/dsl/dsl.rb
+++ b/lib/openhab/dsl/dsl.rb
@@ -19,6 +19,7 @@ require 'openhab/dsl/things'
 require 'openhab/dsl/between'
 require 'openhab/dsl/gems'
 require 'openhab/dsl/persistence'
+require 'openhab/dsl/uid'
 require 'openhab/dsl/units'
 require 'openhab/dsl/states'
 

--- a/lib/openhab/dsl/rules/triggers/channel.rb
+++ b/lib/openhab/dsl/rules/triggers/channel.rb
@@ -15,16 +15,19 @@ module OpenHAB
         #
         # Creates a channel trigger
         #
-        # @param [Array] channels array to create triggers for on form of 'binding_id:type_id:thing_id#channel_id'
+        # @param [String, Channel, ChannelUID, Array<String, Channel, ChannelUID>] channels
+        #   channels to create triggers for in form of 'binding_id:type_id:thing_id#channel_id'
         #   or 'channel_id' if thing is provided
-        # @param [thing] thing to create trigger for if not specified with the channel
-        # @param [String] triggered specific triggering condition to match for trigger
+        # @param [String, Thing, ThingUID, Array<String, Thing, ThingUID>] thing
+        #   thing(s) to create trigger for if not specified with the channel
+        # @param [String, Array<String>] triggered specific triggering condition(s) to match for trigger
         #
-        #
-        def channel(*channels, thing: nil, triggered: nil, attach: nil)
-          channels.flatten.each do |channel|
-            channel = [thing, channel].join(':') if thing
-            logger.trace("Creating channel trigger for channel(#{channel}), thing(#{thing}), trigger(#{triggered})")
+        def channel(*channels, thing: nil, triggered: nil, attach: nil) # rubocop:disable Metrics/AbcSize
+          channels.flatten.product([thing].flatten).each do |(channel, t)|
+            channel = channel.uid if channel.is_a?(org.openhab.core.thing.Channel)
+            t = t.uid if t.is_a?(Thing)
+            channel = [t, channel].compact.join(':')
+            logger.trace("Creating channel trigger for channel(#{channel}), thing(#{t}), trigger(#{triggered})")
             [triggered].flatten.each do |trigger|
               create_channel_trigger(channel, trigger, attach)
             end
@@ -36,14 +39,13 @@ module OpenHAB
         #
         # Create a trigger for a channel
         #
-        # @param [Channel] channel to look for triggers
-        # @param [Trigger] trigger specific channel trigger to match
+        # @param [String] channel to look for triggers
+        # @param [String] trigger specific channel trigger to match
         #
         #
         def create_channel_trigger(channel, trigger, attach)
           config = { 'channelUID' => channel }
           config['event'] = trigger.to_s unless trigger.nil?
-          config['channelUID'] = channel
           logger.trace("Creating Change Trigger for #{config}")
           append_trigger(Trigger::CHANNEL_EVENT, config, attach: attach)
         end

--- a/lib/openhab/dsl/things.rb
+++ b/lib/openhab/dsl/things.rb
@@ -14,7 +14,7 @@ module OpenHAB
     # Support for OpenHAB Things
     #
     module Things
-      java_import Java::OrgOpenhabCoreThing::ThingStatus
+      java_import org.openhab.core.thing.ThingStatus
       include OpenHAB::Log
 
       #

--- a/lib/openhab/dsl/uid.rb
+++ b/lib/openhab/dsl/uid.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module DSL
+    java_import org.openhab.core.common.AbstractUID
+    java_import org.openhab.core.thing.ThingTypeUID
+
+    # Adds methods to core OpenHAB AbstractUID to make it more natural in Ruby
+    class AbstractUID
+      # implicit conversion to string
+      alias to_str to_s
+      # inspect result is just the string representation
+      alias inspect to_s
+
+      # compares if equal to `other`, including string conversion
+      # @return [true, false]
+      def ==(other)
+        return true if equals(other)
+
+        to_s == other
+      end
+    end
+
+    # Adds methods to core OpenHAB ThingUID to make it more natural in Ruby
+    class ThingUID
+      # Returns the id of the binding this thing belongs to
+      # @return [String]
+      def binding_id
+        get_segment(0)
+      end
+    end
+
+    # Adds methods to core OpenHAB ThingTypeUID to make it more natural in Ruby
+    class ThingTypeUID
+      # Returns the id of the binding this thing type belongs to
+      # @return [String]
+      def binding_id
+        get_segment(0)
+      end
+    end
+
+    # have to remove == from all descendant classes so that they'll inherit
+    # the new implementation
+    [org.openhab.core.items.MetadataKey,
+     org.openhab.core.thing.UID,
+     org.openhab.core.thing.ChannelUID,
+     org.openhab.core.thing.ChannelGroupUID,
+     org.openhab.core.thing.ThingUID,
+     org.openhab.core.thing.ThingTypeUID,
+     org.openhab.core.thing.type.ChannelTypeUID,
+     org.openhab.core.thing.type.ChannelGroupTypeUID].each do |klass|
+      klass.remove_method(:==)
+    end
+  end
+end


### PR DESCRIPTION
this is useful if you're auto-discovering the channels by filtering the known things