### PR TITLE
fix(monthday): fix equality comparison against string and allow parsing single digit month-days

### DIFF
--- a/docs/usage/misc/month_day.md
+++ b/docs/usage/misc/month_day.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: MonthDay
+nav_order: 6
+has_children: false
+parent: Misc
+grand_parent: Usage
+---
+
+# MonthDay
+
+MonthDay class from [java.time.MonthDay](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/MonthDay.html) can be used in rules for month-date related logic. Notable Methods:
+
+| Method       | Parameter  | Description                                                                                                                                                                  |
+| ------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| parse        | String     | Creates a MonthDay object with a given time string. The format is `[--]M-d`. Both the month and the date can be a one or two digit number, and optionally prefixed with `--` |
+| now          |            | Creates a MonthDay object that represents the current month-day                                                                                                              |
+| of           | month, day | Creates a MonthDay with the given month and day                                                                                                                              |
+| month_value  |            | Returns the month part of the object as a number between 1 and 12                                                                                                            |     |
+| month        |            | Returns the month part of the object as java.time.Month enum                                                                                                                 |
+| day_of_month |            | Returns the second part of the object                                                                                                                                        |
+
+For a full list of methods supported by MonthDay, please see the link above.
+
+A MonthDay object can be compared against another MonthDay object or a parseable string representation of month-day.
+
+## Examples
+
+```ruby
+#Create a MonthDay object
+end_of_june = MonthDay.of(6, 30)
+
+if MonthDay.now > end_of_june # comparing two MonthDay objects
+  # do something
+elsif MonthDay.now < '03-05' # comparison against a string representation for March 5th
+  #do something
+end
+halloween = MonthDay.parse('10-31')
+```
+
+## between
+
+`between` creates a MonthDay range that can be used to check if another MonthDay is within that range.
+
+```ruby
+logger.info("Within month-day range") if between('02-20'..'06-01').cover? MonthDay.now
+
+case MonthDay.now
+
+when between('01-01'..'03-31')
+ logger.info("First quarter")
+when between('04-01'..'06-30')
+ logger.info("Second quarter")
+end
+```

--- a/features/comparisons.feature
+++ b/features/comparisons.feature
@@ -423,6 +423,13 @@ Feature: comparisons
         [ '2021-01-01T00:00:00+00:00' , '=='  , DateTimeType.parse('2021-01-01T00:00:00+00:00'), true  ]  ,
         [ '2021-01-01T00:00:00+01:00' , '!='  , DateTimeType.parse('2021-01-01T00:00:00+00:00'), true  ]  ,
 
+        # MonthDay
+        [ MonthDay.of(2, 3)           , '=='  , '02-03'     , true],
+        [ MonthDay.of(2, 3)           , '=='  , '02-3'      , true],
+        [ MonthDay.of(2, 3)           , '=='  , '2-03'      , true],
+        [ MonthDay.of(2, 3)           , '=='  , '2-3'       , true],
+        [ MonthDay.of(2, 3)           , '=='  , '--2-3'     , true],
+
         # HSBType
         [ HSBType.new(0, 100, 100)    , '=='  , Color                       , true  ]  ,
         [ HSBType.new(0, 100, 100)    , '!='  , Color                       , false ]  ,

--- a/lib/openhab/dsl/time/month_day.rb
+++ b/lib/openhab/dsl/time/month_day.rb
@@ -107,10 +107,13 @@ module OpenHAB
       # Extend MonthDay java object with some helper methods
       class MonthDay
         include OpenHAB::Log
+        java_import java.time.format.DateTimeFormatter
         # Parse MonthDay string as defined with by Monthday class without leading double dash "--"
         def self.parse(string)
-          ##          string = "--#{string}" unless string.to_s.start_with? '--'
-          java_send :parse, [java.lang.CharSequence], "--#{string}"
+          logger.trace("#{self.class}.parse #{string} (#{string.class})")
+          java_send :parse, [java.lang.CharSequence, java.time.format.DateTimeFormatter],
+                    string.to_s,
+                    DateTimeFormatter.ofPattern('[--]M-d')
         end
 
         # Can the supplied object be parsed into a MonthDay
@@ -122,6 +125,9 @@ module OpenHAB
         def to_s
           to_string.delete_prefix('--')
         end
+
+        # remove the inherited #== method to use our <=> below
+        remove_method :==
 
         # Extends MonthDay comparison to support Strings
         # Necessary to support mixed ranges of Strings and MonthDay types


### PR DESCRIPTION
Fix #377 - MonthDay.of(10, 10) == '10-10' wasn't working before.

Allows MonthDay.parse('2-3') format, which is the same as MonthDay.parse('02-03') for the lazy people like me. Also allows leading `--` if provided.

Added docs.