### PR TITLE
fix(item_groups): fix Item#groups returning nil sometimes

### DIFF
--- a/features/items.feature
+++ b/features/items.feature
@@ -204,6 +204,20 @@ Feature:  items
     When I deploy the rules file
     Then It should log "Number3 is in groups Numbers, PrimeNumbers" within 5 seconds
 
+  Scenario: Dangling group references are ignored
+    Given groups:
+      | name         |
+      | Numbers      |
+    Given items:
+      | type   | name    | groups                |
+      | Number | Number3 | Numbers, PrimeNumbers |
+    And code in a rules file
+      """
+      logger.info("Number3 is in groups #{Number3.groups.map(&:name).join(', ')}$")
+      """
+    When I deploy the rules file
+    Then It should log "Number3 is in groups Numbers$" within 5 seconds
+
   Scenario Outline: Items can be used as hash keys
     # Ref: https://github.com/boc-tothefuture/openhab-jruby/issues/252
     Given items:

--- a/lib/openhab/dsl/items/generic_item.rb
+++ b/lib/openhab/dsl/items/generic_item.rb
@@ -135,7 +135,7 @@ module OpenHAB
         # @return [Array<Group>] All groups that this item is part of
         #
         def groups
-          group_names.map { |name| Groups.groups[name] }
+          group_names.map { |name| Groups.groups[name] }.compact
         end
 
         # Return the item's thing if this item is linked with a thing. If an item is linked to more than one thing,


### PR DESCRIPTION
OpenHAB allows you to reference a group item that doesn't exist
(so that it doesn't matter which file your define the group item
in), but we shouldn't be returning nils from `groups`.