### PR TITLE
fix(items): don't exclude GroupItems from `items` global hash

### DIFF
--- a/features/groups.feature
+++ b/features/groups.feature
@@ -229,4 +229,4 @@ Feature:  groups
       logger.info("Item+Group Count: #{(items + groups).count}")
       """
     When I deploy the rules file
-    Then It should log 'Item+Group Count: 8' within 5 seconds
+    Then It should log 'Item+Group Count: 13' within 5 seconds

--- a/lib/openhab/dsl/items/item_registry.rb
+++ b/lib/openhab/dsl/items/item_registry.rb
@@ -35,7 +35,7 @@ module OpenHAB
         # Explicit conversion to array
         # @return [Array]
         def to_a
-          $ir.items.grep_v(org.openhab.core.items.GroupItem) # rubocop:disable Style/GlobalVars
+          $ir.items.to_a # rubocop:disable Style/GlobalVars
         end
       end
 


### PR DESCRIPTION
OpenHAB's DSL rules doesn't, and it can be surprising and annoying when you're
trying to find an item by using Enumerable methods (i.e. `select`)
against items and your item doesn't show up just because it happens
to be a GroupItem. especially since hash lookup (`items["GroupItem"]`)
doesn't have the same restriction.