### PR TITLE
feat(timer): add timers[id].cancel_all shorthand for timer[id].each(&:cancel)

### DIFF
--- a/docs/usage/misc/timers.md
+++ b/docs/usage/misc/timers.md
@@ -21,7 +21,8 @@ After method parameters
 
 Timers with an id are reentrant, by id and block. Reentrant means that when the same id and block are encountered the timer is resheduled rather than creating a second new timer.
 
-Timer Object
+## Timer Object
+
 The timer object has all of the methods of the [OpenHAB Timer](https://www.openhab.org/docs/configuration/actions.html#timers) with a change to the reschedule method to enable it to operate Ruby context. The following methods are available to a Timer object:
 
 | Method           | Parameter | Description                                                                                        |
@@ -34,8 +35,7 @@ The timer object has all of the methods of the [OpenHAB Timer](https://www.openh
 | `running?`       |           | An alias for `Timer::isRunning()`                                                                  |
 | `terminated?`    |           | An alias for `Timer::hasTerminated()`                                                              |
 
-Timers
-Timers with an id can be accessed via the timers[id] method. This method returns a set of timers associated with that id.
+### Examples
 
 ```ruby
 after 5.seconds do
@@ -98,6 +98,10 @@ end
 mytimer.cancel
 ```
 
+## Reentrant Timers
+
+Timers with an `id` can be accessed via the `timers[id]` method. This method returns a set of timers associated with that id. Cancelling the timer(s) with the given `id` can be done by calling `timers[id]&.each(&:cancel)` or by using the shorthand `timers[id]&.cancel_all`.
+
 ```ruby
 # Reentrant timers will automatically reschedule if same block is encountered again with same reentrant object
 rule 'Turn on light for 10 minutes when a closet door is open' do
@@ -122,7 +126,7 @@ after 3.seconds, :id => :foo do
 end
 
 rule 'Cancel timer' do
-  run { timers[:foo]&.each(&:cancel) }
+  run { timers[:foo]&.cancel_all }
   on_start true
 end
 ```

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -232,7 +232,7 @@ Feature:  timer
       end
 
       rule 'Cancel timer' do
-        run { timers[:foo]&.each(&:cancel) }
+        run { timers[:foo]&.cancel_all }
         on_start true
       end
       """
@@ -264,7 +264,7 @@ Feature:  timer
         on_start true
         run do
           logger.info("timers[:foo] is nil before cancel: #{timers[:foo].nil?}")
-          timers[:foo]&.each(&:cancel)
+          timers[:foo]&.cancel_all
           logger.info("timers[:foo] is nil after cancel: #{timers[:foo].nil?}")
         end
       end

--- a/lib/openhab/dsl/timers/manager.rb
+++ b/lib/openhab/dsl/timers/manager.rb
@@ -39,7 +39,7 @@ module OpenHAB
 
           if timer.respond_to? :id
             logger.trace("Adding #{timer} with id #{timer.id.inspect} timer ids")
-            @timer_ids[timer.id] = Set.new unless @timer_ids[timer.id]
+            @timer_ids[timer.id] = TimerSet.new unless @timer_ids[timer.id]
             @timer_ids[timer.id] << timer
           end
 
@@ -85,6 +85,19 @@ module OpenHAB
           @timer_ids.clear
           @reentrant_timers.clear
           @timers.clear
+        end
+      end
+
+      #
+      # Provide additional methods for the timers set
+      #
+      class TimerSet < Set
+        #
+        # A shorthand to cancel all the timer objects held within the set
+        # so that timers[timer_id].cancel_all is equivalent to timers[timer_id].each(&:cancel)
+        #
+        def cancel_all
+          each(&:cancel)
         end
       end
     end


### PR DESCRIPTION
I got tired of writing `timers[id].each(&:cancel)`. This PR makes it possible to call `timers[id].cancel_all`

