### PR TITLE
refactor(logging)!: rename log prefix from jsr223.jruby to org.openhab.automation.jruby

### DIFF
--- a/docs/usage/misc/logging.md
+++ b/docs/usage/misc/logging.md
@@ -9,25 +9,23 @@ grand_parent: Usage
 
 # Logging
 
-Logging is available everywhere through the logger object. 
+Logging is available everywhere through the logger object.
 
 Logging placed outside of a rule will have the name of the file appened to the logger name. The following entries are in a file named 'log_test.rb'
 
 ```ruby
-logger.trace('Test logging at trace') # 2020-12-03 18:05:20.903 [TRACE] [jsr223.jruby.log_test               ] - Test logging at trace
-logger.debug('Test logging at debug') # 2020-12-03 18:05:32.020 [DEBUG] [jsr223.jruby.log_test               ] - Test logging at debug
-logger.warn('Test logging at warn') # 2020-12-03 18:05:41.817 [WARN ] [jsr223.jruby.log_test               ] - Test logging at warn
-logger.info('Test logging at info') # 2020-12-03 18:05:41.817 [INFO ] [jsr223.jruby.log_test               ] - Test logging at info
-logger.error('Test logging at error') # 2020-12-03 18:06:02.021 [ERROR] [jsr223.jruby.log_test               ] - Test logging at error
+logger.trace('Test logging at trace') # 2020-12-03 18:05:20.903 [TRACE] [org.openhab.automation.jruby.log_test] - Test logging at trace
+logger.debug('Test logging at debug') # 2020-12-03 18:05:32.020 [DEBUG] [org.openhab.automation.jruby.log_test] - Test logging at debug
+logger.warn('Test logging at warn')   # 2020-12-03 18:05:41.817 [WARN ] [org.openhab.automation.jruby.log_test] - Test logging at warn
+logger.info('Test logging at info')   # 2020-12-03 18:05:41.817 [INFO ] [org.openhab.automation.jruby.log_test] - Test logging at info
+logger.error('Test logging at error') # 2020-12-03 18:06:02.021 [ERROR] [org.openhab.automation.jruby.log_test] - Test logging at error
 ```
 
 Logging inside of a rule will have the name of the rule appened to the logger name. The following entries are in a file named 'log_test.rb'
 
 ```ruby
 rule 'foo' do
-  run { logger.trace('Test logging at trace') } # 2020-12-03 18:05:20.903 [TRACE] [jsr223.jruby.log_test.foo               ] - Test logging at trace
+  run { logger.trace('Test logging at trace') } # 2020-12-03 18:05:20.903 [TRACE] [org.openhab.automation.jruby.log_test.foo] - Test logging at trace
   on_start
 end
 ```
-
-

--- a/features/gem_install.feature
+++ b/features/gem_install.feature
@@ -5,6 +5,9 @@ Feature:  gem_install
     Given Clean OpenHAB with latest Ruby Libraries
 
   @reset_library
+  # This will install the current release version from rubygems.org
+  # Running a rule here may cause errors if the new version is not
+  # compatible with the release version
   Scenario: Install OpenHAB helper library
     Given OpenHAB is stopped
     And GEM_HOME is empty
@@ -14,12 +17,6 @@ Feature:  gem_install
       org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>4.0
       org.openhab.automation.jrubyscripting:rubylib=<%= ruby_lib_dir %>
       """
-    And code in a rules file:
-      """
-      logger.info("OpenHAB helper library is at #{OpenHAB::VERSION}")
-      """
     When I start OpenHAB
     Then It should log 'Installing Gem: openhab-scripting' within 180 seconds
-    And I deploy the rules file
-    Then It should log 'OpenHAB helper library is at' within 200 seconds
 

--- a/features/logging.feature
+++ b/features/logging.feature
@@ -36,7 +36,7 @@ Feature:  logging
       logger.info("Hello World!")
       """
     When I deploy the rules file named "foo_bar.rb"
-    Then It should log only "Hello World!" at level "INFO" from 'jsr223.jruby.foo_bar' within 5 seconds
+    Then It should log only "Hello World!" at level "INFO" from 'org.openhab.automation.jruby.foo_bar' within 5 seconds
 
 
   Scenario: Logging should include rule name inside a rule
@@ -49,7 +49,7 @@ Feature:  logging
 
       """
     When I deploy the rules file named "log_rule_test.rb"
-    Then It should log only "Log Test" at level "INFO" from 'jsr223.jruby.log_rule_test.log_test' within 5 seconds
+    Then It should log only "Log Test" at level "INFO" from 'org.openhab.automation.jruby.log_rule_test.log_test' within 5 seconds
 
   Scenario: Methods called by a rule have the rule file and name in their log name
     Given code in a rules file
@@ -65,14 +65,14 @@ Feature:  logging
 
       """
     When I deploy the rules file named "log_file.rb"
-    Then It should log only "Foo" at level "INFO" from 'jsr223.jruby.log_file.log_test' within 5 seconds
+    Then It should log only "Foo" at level "INFO" from 'org.openhab.automation.jruby.log_file.log_test' within 5 seconds
 
   Scenario: Logs in after blocks (timers) should have file and rule name in log prefix
     Given code in a rules file
       """
       rule 'log test' do
         on_start
-        run do 
+        run do
           after 1.second do
             logger.info('Bar')
           end
@@ -80,23 +80,23 @@ Feature:  logging
       end
       """
     When I deploy the rules file named "log_file.rb"
-    Then It should log only "Bar" at level "INFO" from 'jsr223.jruby.log_file.log_test' within 5 seconds
+    Then It should log only "Bar" at level "INFO" from 'org.openhab.automation.jruby.log_file.log_test' within 5 seconds
 
   Scenario: Logs in blocks after trigger delays should have file and rule name in log prefix
-   Given items:
-    | type   | name | state  |
-    | Number | Foo  | 0      |
+    Given items:
+      | type   | name | state |
+      | Number | Foo  | 0     |
     Given a rule:
       """
       rule 'log test' do
         changed Foo, to: 5, for: 3.seconds
-        run do 
+        run do
           logger.info('Baz')
         end
       end
       """
     When I deploy the rules file named "log_file.rb"
     And item "Foo" state is changed to "5"
-    Then It should log only "Baz" at level "INFO" from 'jsr223.jruby.log_file.log_test' within 8 seconds
+    Then It should log only "Baz" at level "INFO" from 'org.openhab.automation.jruby.log_file.log_test' within 8 seconds
 
 

--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -42,7 +42,7 @@ end
 
 # rubocop:disable Metrics/LineLength
 Then('It should log only {string} at level {string} from {string} within {int} seconds') do |entry, level, logger, seconds|
-  # 2021-11-15 19:24:34.574 [INFO ] [jsr223.jruby.rules.log_test         ] - Log Test
+  # 2021-11-15 19:24:34.574 [INFO ] [org.openhab.automation.jruby.rules.log_test] - Log Test
   # Trim level to the right most 36 chars (per logging config)
   logger_length = 36
   logger = logger[-logger_length, logger_length] if logger.length > logger_length
@@ -233,7 +233,7 @@ Given('metadata added to {string} in namespace {string}:') do |item, namespace, 
 end
 
 Given('(set )log level (to ){word}') do |level|
-  set_log_level('jsr223.jruby', level)
+  set_log_level('org.openhab.automation.jruby', level)
   set_log_level('org.openhab.automation.jrubyscripting', level)
   set_log_level('org.openhab.core.automation', level)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,7 +22,7 @@ After('@reset_library') do
 end
 
 After('@log_level_changed') do
-  set_log_level('jsr223.jruby', 'TRACE')
+  set_log_level('org.openhab.automation.jruby', 'TRACE')
   set_log_level('org.openhab.automation.jrubyscripting', 'TRACE')
   set_log_level('org.openhab.core.automation', 'TRACE')
 end

--- a/lib/openhab/log/configuration.rb
+++ b/lib/openhab/log/configuration.rb
@@ -6,7 +6,7 @@ module OpenHAB
     # This module holds global configuration values
     module Configuration
       # -*- coding: utf-8 -*-
-      LOG_PREFIX = 'jsr223.jruby'
+      LOG_PREFIX = 'org.openhab.automation.jruby'
 
       #
       # Gets the log prefix

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -184,7 +184,7 @@ namespace :openhab do
     # Set log levels
     state(task.name) do
       start
-      karaf('log:set TRACE jsr223')
+      karaf('log:set TRACE org.openhab.automation.jruby')
       karaf('log:set TRACE org.openhab.core.automation')
       karaf('log:set TRACE org.openhab.automation.jrubyscripting')
       karaf('openhab:users add foo foo administrator')


### PR DESCRIPTION
Resolve #464 

jsr223.jruby is a custom log prefix that would require users to specifically enable in the karaf console. This is an extra step that could be avoided to improve user's first time experience.

org.openhab prefix is set to INFO by default

In Openhab 3.2 distro, a new prefix was created `org.openhab.automation.script`, however it is set to TRACE by default, making it impractical for us to use.

This PR chose `org.openhab.automation.jruby` as a unique log prefix to use, relying on the `org.openhab` default as INFO.