### PR TITLE
fix(java_class): fix java to ruby class

### DIFF
--- a/features/gem_install.feature
+++ b/features/gem_install.feature
@@ -5,6 +5,9 @@ Feature:  gem_install
     Given Clean OpenHAB with latest Ruby Libraries
 
   @reset_library
+  # This will install the current release version from rubygems.org
+  # Running a rule here may cause errors if the new version is not
+  # compatible with the release version
   Scenario: Install OpenHAB helper library
     Given OpenHAB is stopped
     And GEM_HOME is empty
@@ -14,12 +17,6 @@ Feature:  gem_install
       org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>4.0
       org.openhab.automation.jrubyscripting:rubylib=<%= ruby_lib_dir %>
       """
-    And code in a rules file:
-      """
-      logger.info("OpenHAB helper library is at #{OpenHAB::VERSION}")
-      """
     When I start OpenHAB
     Then It should log 'Installing Gem: openhab-scripting' within 180 seconds
-    And I deploy the rules file
-    Then It should log 'OpenHAB helper library is at' within 200 seconds
 

--- a/lib/openhab/dsl/types/date_time_type.rb
+++ b/lib/openhab/dsl/types/date_time_type.rb
@@ -7,8 +7,8 @@ require 'java'
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.DateTimeType
-      java_import java.time.ZonedDateTime
+      DateTimeType = org.openhab.core.library.types.DateTimeType
+      java_import java.time.ZonedDateTime # This is needed for the addon prior to ruby_class fix (OH 3.2.0)
 
       # global alias
       ::DateTimeType = DateTimeType

--- a/lib/openhab/dsl/types/decimal_type.rb
+++ b/lib/openhab/dsl/types/decimal_type.rb
@@ -6,7 +6,7 @@ require_relative 'numeric_type'
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.DecimalType
+      DecimalType = org.openhab.core.library.types.DecimalType
 
       #
       # Add methods to core OpenHAB DecimalType to make it behave as a Ruby

--- a/lib/openhab/dsl/types/hsb_type.rb
+++ b/lib/openhab/dsl/types/hsb_type.rb
@@ -6,7 +6,7 @@ require_relative 'percent_type'
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.HSBType
+      HSBType = org.openhab.core.library.types.HSBType
 
       # global alias
       ::HSBType = HSBType

--- a/lib/openhab/dsl/types/increase_decrease_type.rb
+++ b/lib/openhab/dsl/types/increase_decrease_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.IncreaseDecreaseType
+      IncreaseDecreaseType = org.openhab.core.library.types.IncreaseDecreaseType
 
       # Adds methods to core OpenHAB IncreaseDecreaseType to make it more
       # natural in Ruby

--- a/lib/openhab/dsl/types/next_previous_type.rb
+++ b/lib/openhab/dsl/types/next_previous_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.NextPreviousType
+      NextPreviousType = org.openhab.core.library.types.NextPreviousType
 
       # Adds methods to core OpenHAB NextPreviousType to make it more
       # natural in Ruby

--- a/lib/openhab/dsl/types/on_off_type.rb
+++ b/lib/openhab/dsl/types/on_off_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.OnOffType
+      OnOffType = org.openhab.core.library.types.OnOffType
 
       # Adds methods to core OpenHAB OnOffType to make it more natural in Ruby
       class OnOffType

--- a/lib/openhab/dsl/types/open_closed_type.rb
+++ b/lib/openhab/dsl/types/open_closed_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.OpenClosedType
+      OpenClosedType = org.openhab.core.library.types.OpenClosedType
 
       # Adds methods to core OpenHAB OpenClosedType to make it more natural in Ruby
       class OpenClosedType

--- a/lib/openhab/dsl/types/percent_type.rb
+++ b/lib/openhab/dsl/types/percent_type.rb
@@ -5,7 +5,7 @@ require_relative 'decimal_type'
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.PercentType
+      PercentType = org.openhab.core.library.types.PercentType
 
       # global alias
       ::PercentType = PercentType

--- a/lib/openhab/dsl/types/play_pause_type.rb
+++ b/lib/openhab/dsl/types/play_pause_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.PlayPauseType
+      PlayPauseType = org.openhab.core.library.types.PlayPauseType
 
       # Adds methods to core OpenHAB PlayPauseType to make it more
       # natural in Ruby

--- a/lib/openhab/dsl/types/point_type.rb
+++ b/lib/openhab/dsl/types/point_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.PointType
+      PointType = org.openhab.core.library.types.PointType
 
       # global scope
       # @!visibility private

--- a/lib/openhab/dsl/types/quantity_type.rb
+++ b/lib/openhab/dsl/types/quantity_type.rb
@@ -5,7 +5,7 @@ require_relative 'numeric_type'
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.QuantityType
+      QuantityType = org.openhab.core.library.types.QuantityType
 
       # global alias
       ::QuantityType = QuantityType

--- a/lib/openhab/dsl/types/refresh_type.rb
+++ b/lib/openhab/dsl/types/refresh_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.types.RefreshType
+      RefreshType = org.openhab.core.types.RefreshType
 
       # Adds methods to core OpenHAB RefreshType to make it more natural in Ruby
       class RefreshType # rubocop:disable Lint/EmptyClass

--- a/lib/openhab/dsl/types/rewind_fastforward_type.rb
+++ b/lib/openhab/dsl/types/rewind_fastforward_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.RewindFastforwardType
+      RewindFastforwardType = org.openhab.core.library.types.RewindFastforwardType
 
       # Adds methods to core OpenHAB RewindFastforwardType to make it more
       # natural in Ruby

--- a/lib/openhab/dsl/types/stop_move_type.rb
+++ b/lib/openhab/dsl/types/stop_move_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.StopMoveType
+      StopMoveType = org.openhab.core.library.types.StopMoveType
 
       # Adds methods to core OpenHAB StopMoveType to make it more
       # natural in Ruby

--- a/lib/openhab/dsl/types/string_type.rb
+++ b/lib/openhab/dsl/types/string_type.rb
@@ -7,7 +7,7 @@ require_relative 'comparable_type'
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.StringType
+      StringType = org.openhab.core.library.types.StringType
 
       #
       # Add methods to core OpenHAB StringType to make it behave as a Ruby

--- a/lib/openhab/dsl/types/un_def_type.rb
+++ b/lib/openhab/dsl/types/un_def_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.types.UnDefType
+      UnDefType = org.openhab.core.types.UnDefType
 
       # Adds methods to core OpenHAB UnDefType to make it more natural in Ruby
       class UnDefType # rubocop:disable Lint/EmptyClass

--- a/lib/openhab/dsl/types/up_down_type.rb
+++ b/lib/openhab/dsl/types/up_down_type.rb
@@ -3,7 +3,7 @@
 module OpenHAB
   module DSL
     module Types
-      java_import org.openhab.core.library.types.UpDownType
+      UpDownType = org.openhab.core.library.types.UpDownType
 
       # Adds methods to core OpenHAB UpDownType to make it more natural in Ruby
       class UpDownType


### PR DESCRIPTION
Resolve #482 

This PR makes openhab-jruby library compatible with the fix to be made in the jrubyscripting bundle that addresses #482. This PR should be compatible with the bundle before the fix (i.e. the bundle that shipped with openhab 3.2) as well.