### PR TITLE
ci(feature_installation): do not reinstall openhab feature

### DIFF
--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -194,12 +194,7 @@ When('channel {string} is triggered') do |channel|
 end
 
 Given('feature {string} installed') do |feature|
-  openhab_client("feature:install #{feature}")
-  wait_until(seconds: 10, msg: "Feature #{feature} not started") do
-    openhab_client('feature:list').stdout.lines.grep(/#{feature}/).any? { |line| line.include? 'Started' }
-  end
-  sleep 60 # System seems unsettled after adding a feature.. proper way to do this would be set
-  # logging for feature to debug and move on after we see that log line in the wait_until
+  install_feature(feature)
 end
 
 When('channel {string} is triggered with {string}') do |channel, event|

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -149,6 +149,21 @@ def link_item(item_name:, channel_uid:)
   Rest.link_item(item_name: item_name, channel_uid: channel_uid)
 end
 
+def install_feature(feature)
+  return if feature_installed?(feature)
+
+  openhab_client("feature:install #{feature}")
+  wait_until(seconds: 10, msg: "Feature #{feature} not started") do
+    feature_installed?(feature)
+  end
+  sleep 60 # System seems unsettled after adding a feature.. proper way to do this would be set
+  # logging for feature to debug and move on after we see that log line in the wait_until
+end
+
+def feature_installed?(feature)
+  openhab_client('feature:list').stdout.lines.grep(/#{feature}/).any? { |line| line.include? 'Started' }
+end
+
 def truncate_log
   File.open(openhab_log, File::TRUNC)
 end


### PR DESCRIPTION
Resolve #481 

Skip feature installation (which includes a 60 second wait) if it's already installed, instead of re-installing it (and waiting for 60 seconds) for each scenario.