### PR TITLE
ci(bundle): test against the new jrubyscripting bundle

### DIFF
--- a/features/bundle.feature
+++ b/features/bundle.feature
@@ -1,0 +1,16 @@
+Feature: bundle
+  Verify the jrubyscripting bundle
+
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
+
+  @wip
+  Scenario: Check bundle version
+    Given The version of 'org.openhab.automation.jrubyscripting' bundle is '3.3.0.202201150335'
+    And a rule
+      """
+      logger.info 'Hello'
+      """
+    When I deploy the rule
+    Then It should log 'Hello' within 5 seconds
+

--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -236,3 +236,8 @@ end
 Given('log level for {word} is set to {word}') do |bundle, level|
   set_log_level(bundle, level)
 end
+
+Given('The version of {string} bundle is {string}') do |bundle, version|
+  actual_version = bundle_version(bundle)
+  raise "'#{bundle}' version is '#{actual_version}'" unless actual_version == version
+end

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -227,3 +227,8 @@ def check_auth(&block)
   yield.then { |response| retry_if_unauthorized(response, &block) }
        .tap { |response| raise "Error in response: #{response.inspect}" unless response.success? }
 end
+
+def bundle_version(bundle)
+  output = openhab_client("bundle:list --no-format #{bundle}").out
+  output.lines.last.split[3].chomp
+end

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -18,6 +18,9 @@ namespace :openhab do
   @state_dir = File.join(OPENHAB_DIR, 'rake_state')
   @services_config_file = File.join(OPENHAB_DIR, 'conf/services/jruby.cfg')
   @addons_config_file = File.join(OPENHAB_DIR, 'conf/services/addons.cfg')
+  # Temporary bundle for testing
+  # @jruby_bundle = 'https://github.com/jimtng/openhab-addons/releases/download/v0.1/org.openhab.automation.jrubyscripting-3.3.0-SNAPSHOT.jar'
+  @jruby_bundle = 'https://ci.openhab.org/job/openHAB-Addons/lastStableBuild/artifact/bundles/org.openhab.automation.jrubyscripting/target/org.openhab.automation.jrubyscripting-3.3.0-SNAPSHOT.jar'
 
   CLOBBER << OPENHAB_DIR
   CLOBBER << @services_config_file
@@ -164,7 +167,14 @@ namespace :openhab do
   desc 'Install JRuby Bundle'
   task bundle: [:download, :services, @deploy_dir] do |task|
     state(task.name) do
-      File.write(@addons_config_file, "\nautomation=jrubyscripting\n", mode: 'a')
+      # Temporarily disabling this for testing with new addon
+      # File.write(@addons_config_file, "\nautomation=jrubyscripting\n", mode: 'a')
+      # Temporary bundle
+      start
+      unless karaf('bundle:list --no-format org.openhab.automation.jrubyscripting').include?('Installed')
+        karaf("bundle:install #{@jruby_bundle}")
+      end
+      karaf("bundle:start #{bundle_id}")
     end
   end
 


### PR DESCRIPTION
This Draft PR is just so I can run tests against the new jrubyscripting bundle. It is not to be merged.