### PR TITLE
fix(logger): incorrect logger prefix on non standard gem_home path

### DIFF
--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -245,9 +245,8 @@ module OpenHAB
       #
       def log_caller
         caller_locations.map(&:path)
-                        .grep_v(%r{openhab/core/})
                         .grep_v(/rubygems/)
-                        .grep_v(%r{lib/ruby})
+                        .grep_v(/openhab-scripting/)
                         .first
                         .then { |caller| File.basename(caller, '.*') if caller }
       end


### PR DESCRIPTION
Resolve #509