### PR TITLE
fix(string_type): direct regex comparison and inspect

### DIFF
--- a/features/string_type.feature
+++ b/features/string_type.feature
@@ -8,10 +8,19 @@ Feature:  string_type
     Given code in a rules file
       """
       java_import org.openhab.core.library.types.StringType
-      logger.info("StringType inspected: #{StringType.new('my_string')}")
+      logger.info("StringType inspected: #{StringType.new('my_string').inspect}")
       """
     When I deploy the rules file
-    Then It should log "StringType inspected: my_string" within 5 seconds
+    Then It should log 'StringType inspected: "my_string"' within 5 seconds
+
+  Scenario: StringType converts to a string
+    Given code in a rules file
+      """
+      java_import org.openhab.core.library.types.StringType
+      logger.info("StringType printed: #{StringType.new('my_string')}")
+      """
+    When I deploy the rules file
+    Then It should log "StringType printed: my_string" within 5 seconds
 
   Scenario: StringType can be used in a case with a regex
     Given code in a rules file
@@ -19,6 +28,19 @@ Feature:  string_type
       java_import org.openhab.core.library.types.StringType
       case StringType.new("hi")
       when /hi/ then logger.info("matched")
+      else
+        logger.info("did not match")
+      end
+      """
+    When I deploy the rules file
+    Then It should log "matched" within 5 seconds
+
+  Scenario: StringType can use =~ operator
+    Given code in a rules file
+      """
+      java_import org.openhab.core.library.types.StringType
+      if StringType.new("hi") =~ /hi/
+        logger.info("matched")
       else
         logger.info("did not match")
       end

--- a/lib/openhab/dsl/types/string_type.rb
+++ b/lib/openhab/dsl/types/string_type.rb
@@ -80,7 +80,7 @@ module OpenHAB
         end
 
         # any method that exists on String gets forwarded to to_s
-        delegate (String.instance_methods - instance_methods) => :to_s
+        delegate (String.instance_methods - instance_methods + %w[=~ inspect]) => :to_s
       end
     end
   end


### PR DESCRIPTION
 * StringType#inspect should call String#inspect, not StringType#toFullString
or whatever java-ism JRuby defaults to.
 * StringType#=~ should work properly, instead of just defaulting to calling
   StringType#==