### PR TITLE
fix(script_thing_actions): adapt to changes in openhab 3.3

### DIFF
--- a/lib/openhab/dsl/monkey_patch/actions/script_thing_actions.rb
+++ b/lib/openhab/dsl/monkey_patch/actions/script_thing_actions.rb
@@ -9,12 +9,10 @@ module OpenHAB
       # Patches OpenHAB actions
       #
       module Actions
-        java_import Java::OrgOpenhabCoreAutomationModuleScriptInternalDefaultscope::ScriptThingActions
-
         #
         # MonkeyPatching ScriptThingActions
         #
-        class ScriptThingActions
+        class << $actions # rubocop:disable Style/GlobalVars
           field_reader :THING_ACTIONS_MAP
 
           #
@@ -23,7 +21,7 @@ module OpenHAB
           # @return [Set] of keys for defined actions in the form of 'scope-thing_uid'
           #
           def action_keys
-            ScriptThingActions.THING_ACTIONS_MAP.keys
+            self.class.THING_ACTIONS_MAP.keys
           end
         end
       end


### PR DESCRIPTION
[Recent changes in openhab-core](https://github.com/openhab/openhab-core/pull/2723) (a snapshot **After** 3.3.0M1) broke script_thing_actions.rb

```
22:49:28.099 [ERROR] [ript.internal.ScriptEngineManagerImpl] - Error during evaluation of script 'file:/openhab/conf/automation/jsr223/ruby/test2.rb': Error during evaluation of Ruby in /openhab/conf/scripts/ruby/lib/gem_home/gems/openhab-scripting-4.32.0/lib/openhab/dsl/monkey_patch/actions/script_thing_actions.rb at line 22: (TypeError) ScriptThingActions is not a class
```

`org.openhab.core.automation.module.script.internal.defaultscope.ScriptThingActions` was renamed to `org.openhab.core.automation.module.script.internal.defaultscope.ScriptThingActionsImpl`

This PR should hopefully make it compatible with pre and post change.