### PR TITLE
fix(logger): move logger class into core module to prevent unintentional modification

### DIFF
--- a/features/logging.feature
+++ b/features/logging.feature
@@ -99,4 +99,15 @@ Feature:  logging
     And item "Foo" state is changed to "5"
     Then It should log only "Baz" at level "INFO" from 'org.openhab.automation.jruby.log_file.log_test' within 8 seconds
 
+  Scenario: Logger works after requiring third party gems
+    Given code in a rules file
+      """
+      gemfile do
+        source 'https://rubygems.org'
+        gem 'httparty'
+      end
 
+      logger.info("OpenHAB Rules!")
+      """
+    When I deploy the rules file
+    Then It should log "OpenHAB Rules!" within 5 seconds

--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -8,7 +8,8 @@ module OpenHAB
   #
   # Provides access to the OpenHAB logging using a Ruby logging methods
   #
-  module Log
+
+  module Core
     #
     # Ruby Logger that forwards messages at appropriate levels to OpenHAB Logger
     #
@@ -105,7 +106,9 @@ module OpenHAB
       #
       def log_exception(exception, rule_name)
         exception = clean_backtrace(exception)
-        error { "#{exception.message} (#{exception.class})\nIn rule: #{rule_name}\n#{exception.backtrace&.join("\n")}" }
+        error do
+          "#{exception.message} (#{exception.class})\nIn rule: #{rule_name}\n#{exception.backtrace&.join("\n")}"
+        end
       end
 
       private
@@ -152,6 +155,12 @@ module OpenHAB
         end
       end
     end
+  end
+
+  module Log
+    #
+    # Ruby Logger that forwards messages at appropriate levels to OpenHAB Logger
+    #
 
     # Logger caches
     @loggers = {}
@@ -180,7 +189,7 @@ module OpenHAB
         # of logger name requires lots of operations and logger
         # names for some objects are specific to the class
         logger_name = logger_name(object)
-        @loggers[logger_name] ||= Logger.new(logger_name)
+        @loggers[logger_name] ||= OpenHAB::Core::Logger.new(logger_name)
       end
 
       private


### PR DESCRIPTION
Fix #523

Because OpenHAB::Log gets included into the top level, the OpenHAB::Log::Logger class then lives on the top level. Due to its generic name, it can be reopened/modified by other libraries that innocently creates their own Logger class. In some cases this can cause errors.

Some libraries known to cause such a problem are httparty and koala.

This PR moves OpenHAB::Log::Logger class to OpenHAB::Core::Logger avoid this issue. 

