### PR TITLE
refactor(on_off_type): reduce to one method call for #!

### DIFF
--- a/lib/openhab/dsl/types/on_off_type.rb
+++ b/lib/openhab/dsl/types/on_off_type.rb
@@ -20,8 +20,7 @@ module OpenHAB
         # Invert the type
         # @return [OnOffType] +OFF+ if +ON+, +ON+ if +OFF+
         def !
-          return OFF if on?
-          return ON if off?
+          on? ? OFF : ON
         end
       end
     end


### PR DESCRIPTION
I noticed when calling SwitchItem.toggle, one comparison was done when the item was in the ON state, but two comparisons were done when the item was in the OFF state.

* When SwitchItem1 is ON and SwitchItem1.toggle is called:
```
23:15:06.403 [TRACE] [.openhab.core.library.types.OnOffType] - (Java::OrgOpenhabCoreLibraryTypes::OnOffType) ON == ON (Java::OrgOpenhabCoreLibraryTypes::OnOffType)
23:15:06.406 [TRACE] [openhab.core.library.items.SwitchItem] - Sending Command OFF to Switch1
```

* When SwitchItem1 is OFF and SwitchItem1.toggle is called:
```
23:15:08.773 [TRACE] [.openhab.core.library.types.OnOffType] - (Java::OrgOpenhabCoreLibraryTypes::OnOffType) OFF == ON (Java::OrgOpenhabCoreLibraryTypes::OnOffType)
23:15:08.776 [TRACE] [.openhab.core.library.types.OnOffType] - (Java::OrgOpenhabCoreLibraryTypes::OnOffType) OFF == OFF (Java::OrgOpenhabCoreLibraryTypes::OnOffType)
23:15:08.777 [TRACE] [openhab.core.library.items.SwitchItem] - Sending Command ON to Switch1
2
```

This PR makes it so there's only one comparison to be done in either case.