### PR TITLE
fix(rule): rule method returns the created rule

### DIFF
--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -222,3 +222,15 @@ Feature: rule_language
       """
     When I deploy the rules file
     Then It should log 'Conf directory is openhab/conf' within 5 seconds
+
+  Scenario: Rule method returns the rule object with Rule UID
+    Given code in a rules file:
+      """
+      rule = rule 'test' do
+        on_start
+        run { logger.info('inside rule') }
+      end
+      logger.info "Rule UID: '#{rule.uid}'"
+      """
+    When I deploy the rules file
+    Then It should log /Rule UID: '.+'/ within 5 seconds

--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -34,7 +34,6 @@ module OpenHAB
       # @yield [] Block executed in context of a RuleConfig
       #
       #
-      # rubocop: disable Metrics/MethodLength
       def rule(rule_name, &block)
         thread_local(RULE_NAME: rule_name) do
           @rule_name = rule_name
@@ -43,12 +42,10 @@ module OpenHAB
           config.guard = Guard::Guard.new(run_context: config.caller, only_if: config.only_if, not_if: config.not_if)
           logger.trace { config.inspect }
           process_rule_config(config)
-          nil # Must return something other than the rule object. See https://github.com/boc-tothefuture/openhab-jruby/issues/438
         end
       rescue StandardError => e
         logger.log_exception(e, @rule_name)
       end
-      # rubocop: enable Metrics/MethodLength
 
       #
       # Cleanup rules in this script file
@@ -71,10 +68,10 @@ module OpenHAB
 
         rule = AutomationRule.new(config: config)
         Rules.script_rules << rule
-        add_rule(rule)
+        added_rule = add_rule(rule)
 
         rule.execute(nil, { 'event' => Struct.new(:attachment).new(config.start_attachment) }) if config.on_start?
-        rule
+        added_rule
       end
 
       #


### PR DESCRIPTION
Related to #419 and #438
Reverts this back to the proper behaviour, which returns the added rule object. This populates the rule.uid which can be used for rule lookup. 

Note: in the `#process_rule_config`, `rule.uid` is blank/nil?. The uid is only available in the `added_rule`.