### PR TITLE
docs(installation): add information about auto-require feature

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -13,10 +13,15 @@ has_children: false
 
 ## Installation
 
+Configure the openHAB JRuby Automation to install the `openhab-scripting` Ruby gem and automatically 
+insert the `require` statement at the beginning of your scripts (_optional_).
+
 ### From the user interface
-1. Go to Settings -> Add-ons -> Automation and install the jrubyscripting automation addon following the [OpenHAB instructions](https://www.openhab.org/docs/
-configuration/addons.html) 
-2. Specify this library (openhab-scripting=~>4.0) as a ruby gem to be installed
+
+1. Go to `Settings -> Add-ons -> Automation` and install the jrubyscripting automation addon following the [openHAB instructions](https://www.openhab.org/docs/configuration/addons.html) 
+2. Go to `Settings -> Other Services -> JRuby Scripting`:
+   * **Ruby Gems**: `openhab-scripting=~>4.0`
+   * **Require Scripts**: `openhab` (openHAB 3.3+: recommended if you are using GUI scripting)
 
 ### Using files
 
@@ -25,6 +30,9 @@ configuration/addons.html)
    Create a file called `jruby.cfg` in `<OPENHAB_CONF>/services/` with the following content:
    ```
    org.openhab.automation.jrubyscripting:gems=openhab-scripting=~>4.0
+   # optional: uncomment the following line if you prefer not having to 
+   # insert require 'openhab' at the top of your scripts.
+   # org.openhab.automation.jrubyscripting:require=openhab
    ```
 
    This configuration with the openhab-scripting gem specified with [pessimistic versioning](https://thoughtbot.com/blog/rubys-pessimistic-operator) will install any version of openhab-scripting greater than or equal to 4.0 but less than 5.0. On system restart if any (non-breaking) new versions of the library are available they will automatically be installed.


### PR DESCRIPTION
Update the installation instructions to include the [auto-require feature added to openhab 3.3](https://github.com/openhab/openhab-addons/pull/12381)