### PR TITLE
fix(ensure): implement ensure.update

### DIFF
--- a/features/ensure_states.feature
+++ b/features/ensure_states.feature
@@ -18,27 +18,33 @@ Feature:  ensure_states
     And code in a rules file
       """
         rule "command received" do
-          received_command DimmerOne
+          <trigger_type> DimmerOne
           run do |event|
-            logger.trace("DimmerOne received command")
+            logger.trace("DimmerOne <trigger_type>")
           end
         end
         DimmerOne.ensure.<command>
       """
     When I deploy the rules file
     Then "DimmerOne" should be in state "<final_state>" within 5 seconds
-    And It should log "DimmerOne received command" within 5 seconds
+    And It should log "DimmerOne <trigger_type>" within 5 seconds
     Examples:
-      | initial_state | command | final_state |
-      | 0             | on      | 100         |
-      | 0             | << ON   | 100         |
-      | 0             | << 50   | 50          |
-      | 50            | off     | 0           |
-      | 50            | << OFF  | 0           |
-      | 50            | << 100  | 100         |
-      | 100           | off     | 0           |
-      | 100           | << OFF  | 0           |
-      | 100           | << 0    | 0           |
+      | initial_state | command     | final_state | trigger_type     |
+      | 0             | on          | 100         | received_command |
+      | 0             | << ON       | 100         | received_command |
+      | 0             | update(ON)  | 100         | updated          |
+      | 0             | << 50       | 50          | received_command |
+      | 0             | update(50)  | 50          | updated          |
+      | 50            | off         | 0           | received_command |
+      | 50            | << OFF      | 0           | received_command |
+      | 50            | update(OFF) | 0           | updated          |
+      | 50            | << 100      | 100         | received_command |
+      | 50            | update(100) | 100         | updated          |
+      | 100           | off         | 0           | received_command |
+      | 100           | << OFF      | 0           | received_command |
+      | 100           | << 0        | 0           | received_command |
+      | 100           | update(0)   | 0           | updated          |
+      | 100           | update(OFF) | 0           | updated          |
 
   Scenario Outline: ensure does not send commands if already in given state
     Given item states:
@@ -47,9 +53,9 @@ Feature:  ensure_states
     And code in a rules file
       """
         rule "command received" do
-          received_command DimmerOne
+          <trigger_type> DimmerOne
           run do |event|
-            logger.trace("DimmerOne received command")
+            logger.trace("DimmerOne <trigger_type>")
           end
         end
         DimmerOne.ensure.<command>
@@ -58,18 +64,22 @@ Feature:  ensure_states
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
     And "DimmerOne" should be in state "<final_state>" within 5 seconds
-    And It should not log "DimmerOne received command" within 5 seconds
+    And It should not log "DimmerOne <trigger_type>" within 5 seconds
     Examples:
-      | initial_state | command | final_state |
-      | 0             | off     | 0           |
-      | 0             | << OFF  | 0           |
-      | 0             | << 0    | 0           |
-      | 50            | on      | 50          |
-      | 50            | << ON   | 50          |
-      | 50            | << 50   | 50          |
-      | 100           | on      | 100         |
-      | 100           | << ON   | 100         |
-      | 100           | << 100  | 100         |
+      | initial_state | command     | final_state | trigger_type     |
+      | 0             | off         | 0           | received_command |
+      | 0             | << OFF      | 0           | received_command |
+      | 0             | << 0        | 0           | received_command |
+      | 0             | update(OFF) | 0           | updated          |
+      | 0             | update(0)   | 0           | updated          |
+      | 50            | on          | 50          | received_command |
+      | 50            | << ON       | 50          | received_command |
+      | 50            | << 50       | 50          | received_command |
+      | 50            | update(50)  | 50          | updated          |
+      | 100           | on          | 100         | received_command |
+      | 100           | << ON       | 100         | received_command |
+      | 100           | << 100      | 100         | received_command |
+      | 100           | update(100) | 100         | updated          |
 
   Scenario Outline: ensure sends commands to group if not in given state
     Given item states:
@@ -151,27 +161,31 @@ Feature:  ensure_states
       | 0              | 100            | << ON   | 100          | 100          |
       | 0              | 100            | << 50   | 50           | 50           |
 
-  Scenario: ensure_states does not send commands if already in given state
+  Scenario Outline: ensure_states does not send commands if already in given state
     Given item states:
       | item      | state |
       | DimmerOne | 0     |
     And code in a rules file
       """
         rule "command received" do
-          received_command DimmerOne
+          <trigger_type> DimmerOne
           run do |event|
-            logger.trace("DimmerOne received command")
+            logger.trace("DimmerOne <trigger_type>")
           end
         end
         ensure_states do
-          DimmerOne.off
+          DimmerOne.<command>
         end
         logger.trace("Command sent")
       """
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
     And "DimmerOne" should be in state "0" within 5 seconds
-    And It should not log "DimmerOne received command" within 5 seconds
+    And It should not log "DimmerOne <trigger_type>" within 5 seconds
+    Examples:
+      | command     | trigger_type     |
+      | off         | received_command |
+      | update(OFF) | updated          |
 
   Scenario Outline: ensure works with boolean commands for SwitchItem
     Given items:
@@ -180,19 +194,42 @@ Feature:  ensure_states
     And code in a rules file
       """
         rule "command received" do
-          received_command Switch1
+          <trigger_type> Switch1
           run do |event|
-            logger.trace("Switch1 received command")
+            logger.trace("Switch1 <trigger_type>")
           end
         end
-        Switch1.ensure.command <command>
+        Switch1.ensure.<command>
         logger.trace("Command sent")
       """
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
     And "Switch1" should be in state "<initial_state>" within 5 seconds
-    And It should not log "Switch1 received command" within 5 seconds
+    And It should not log "Switch1 <trigger_type>" within 5 seconds
     Examples:
-      | initial_state | command |
-      | OFF           | false   |
-      | ON            | true    |
+      | initial_state | command       | trigger_type     |
+      | OFF           | command false | received_command |
+      | ON            | command true  | received_command |
+      | OFF           | update false  | updated          |
+      | ON            | update true   | updated          |
+
+  Scenario: ensure update doesn't send a command
+    Given items:
+      | type   | name    | state |
+      | Switch | Switch1 | OFF   |
+    And code in a rules file
+      """
+        rule "command received" do
+          received_command Switch1
+          run do |event|
+            logger.trace("Switch1 received command")
+          end
+        end
+        Switch1.ensure.update ON
+        logger.trace("Item updated")
+      """
+    When I deploy the rules file
+    Then It should log "Item updated" within 5 seconds
+    And "Switch1" should be in state "ON" within 5 seconds
+    And It should not log "Switch1 received command" within 5 seconds
+

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -50,15 +50,17 @@ module OpenHAB
         # If +ensure_states+ is active (by block or chained method), then
         # check if this item is in the command's state before actually
         # sending the command
-        def command(command)
-          return super unless Thread.current[:ensure_states]
+        %i[command update].each do |ensured_method|
+          define_method(ensured_method) do |command|
+            return super(command) unless Thread.current[:ensure_states]
 
-          logger.trace do
-            "#{name} ensure #{command}, format_type_pre: #{format_type_pre(command)}, current state: #{state}"
+            logger.trace do
+              "#{name} ensure #{command}, format_type_pre: #{format_type_pre(command)}, current state: #{state}"
+            end
+            return if state == format_type_pre(command)
+
+            super(command)
           end
-          return if state == format_type_pre(command)
-
-          super
         end
         alias << command
       end


### PR DESCRIPTION
I noticed that ensure.update is in the docs but wasn't implemented.

Also GroupMembers doesn't have #update. At this point I don't think it's worth adding, as I don't think anyone needs it.