### PR TITLE
ci(openhab): add 3.3.0M2 to the build matrix

### DIFF
--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -2,7 +2,7 @@
 
 require 'json'
 
-OPENHAB_VERSIONS = ['3.2.0'].freeze
+OPENHAB_VERSIONS = ['3.2.0', '3.3.0.M2'].freeze
 
 # rubocop: disable Metrics/BlockLength
 # Disabled due to part of buid / potentially refactor into classes


### PR DESCRIPTION
Unfortunately this would double our test time.