### PR TITLE
fix(timed_command): timed command cancelled by its own command

### DIFF
--- a/lib/openhab/dsl/items/timed_command.rb
+++ b/lib/openhab/dsl/items/timed_command.rb
@@ -49,7 +49,7 @@ module OpenHAB
             return super(command) unless duration
 
             # Timer needs access to rule to disable, rule needs access to timer to cancel.
-            # Using a mutux to ensure neither fires before the other is constructed
+            # Using a mutex to ensure neither fires before the other is constructed
             semaphore = Mutex.new
 
             semaphore.synchronize do
@@ -144,7 +144,7 @@ module OpenHAB
             include OpenHAB::Log
             include OpenHAB::Core::ThreadLocal
 
-            def initialize(timed_command_details, semaphore, &block)
+            def initialize(timed_command_details, semaphore, &block) # rubocop:disable Metric/MethodLength
               super()
               @semaphore = semaphore
               @timed_command_details = timed_command_details
@@ -154,7 +154,8 @@ module OpenHAB
               set_name("Cancels implicit timer for #{timed_command_details.item.id}")
               set_triggers([OpenHAB::DSL::Rules::RuleTriggers.trigger(
                 type: OpenHAB::DSL::Rules::Triggers::Changed::ITEM_STATE_CHANGE,
-                config: { 'itemName' => timed_command_details.item.name }
+                config: { 'itemName' => timed_command_details.item.name,
+                          'previousState' => timed_command_details.command.to_s }
               )])
             end
 


### PR DESCRIPTION
Fix #525 

The timed command:
* Send a command to the item (e.g. ON)
* Set up a timer to revert that command (set it back to OFF)
* Set a rule that will cancel that timer if the state of the item changed. The issue is that here, it expects that the item had already changed to the desired state (ON) before the rule was created.

On a busy/slow system, the item might not have had a chance to change to ON before the rule in step 3 was created. 

When this happened, the rule will trigger due to the change of state (to ON which was initially commanded), cancel the timer, so that the item will never return to OFF.

This PR adds a condition to the rule to prevent this issue.

