### PR TITLE
docs(config): remove footer, google analytics, update edit link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -73,9 +73,9 @@ search:
 heading_anchors: true
 
 # Aux links for the upper right navigation
-#aux_links:
-#  "Just the Docs on GitHub":
-#    - "//github.com/pmarsceill/just-the-docs"
+# aux_links:
+#  "OpenHAB JRuby on GitHub":
+#    - "//github.com/boc-tothefuture/openhab-jruby"
 
 # Makes Aux links open in a new tab. Default is false
 aux_links_new_tab: false
@@ -91,7 +91,7 @@ nav_sort: case_sensitive # Capital letters sorted before lowercase
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
+# footer_content: "Copyright &copy; 2017-2020 Patrick Marsceill. Distributed by an <a href=\"https://github.com/pmarsceill/just-the-docs/tree/master/LICENSE.txt\">MIT license.</a>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
@@ -102,7 +102,7 @@ last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https:/
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page on GitHub"
-gh_edit_repository: "https://github.com/pmarsceill/just-the-docs" # the github URL for your repo
+gh_edit_repository: "https://github.com/boc-tothefuture/openhab-jruby/docs" # the github URL for your repo
 gh_edit_branch: "main" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
@@ -112,8 +112,8 @@ color_scheme: nil
 
 # Google Analytics Tracking (optional)
 # e.g, UA-1234567-89
-ga_tracking: UA-80492189-2
-ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
+#ga_tracking: UA-80492189-2
+#ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true/nil by default)
 
 plugins:
   - jekyll-seo-tag


### PR DESCRIPTION
@boc-tothefuture I wasn't sure whether you've added the google analytics, or was it from the original template? I don't mind it being there if you meant to have it.

Also if you want to add a specific copyright footer, that's OK too. The current one is just a bit confusing / misleading.