### PR TITLE
docs(config): fix the edit on github footer link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@
 
 title: OpenHAB JRuby Script Library
 description: JRuby Scripting Helper Library
-baseurl: "/openhab-jruby/" # the subpath of your site, e.g. /blog
+baseurl: "/openhab-jruby" # the subpath of your site, e.g. /blog
 #url: "https://boc-tothefuture.github.io/" # the base hostname & protocol for your site, e.g. http://example.com
 
 source: "docs/"
@@ -102,9 +102,9 @@ last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https:/
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page on GitHub"
-gh_edit_repository: "https://github.com/boc-tothefuture/openhab-jruby/docs" # the github URL for your repo
+gh_edit_repository: "https://github.com/boc-tothefuture/openhab-jruby" # the github URL for your repo
 gh_edit_branch: "main" # the branch that your docs is served from
-# gh_edit_source: docs # the source that your files originate from
+gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define


### PR DESCRIPTION
It seems that the footer link isn't quite right. I don't know how to generate the pages locally.