### PR TITLE
Update docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,6 +28,7 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 # Build settings
 markdown: kramdown
 remote_theme: pmarsceill/just-the-docs
+theme: just-the-docs
 plugins:
   - jekyll-feed
 

--- a/docs/examples/gem_cleanup.md
+++ b/docs/examples/gem_cleanup.md
@@ -8,7 +8,7 @@ parent: Examples
 
 ## Gem Cleanup
 
-The Openhab JRuby add-on will automatically download and install the latest version of the library according to the [settings in jruby.cfg](../../installation/#installation). Over time, the older versions of the library will accumulate in the gem_home directory. The following code saved as `gem_cleanup.rb` or another name of your choice can be placed in the `jsr223/ruby/personal/` directory to perform uninstallation of the older gem versions.
+The OpenHAB JRuby add-on will automatically download and install the latest version of the library according to the [settings in jruby.cfg]({% link installation/index.md %}#installation). Over time, the older versions of the library will accumulate in the gem_home directory. The following code saved as `gem_cleanup.rb` or another name of your choice can be placed in the `jsr223/ruby/personal/` directory to perform uninstallation of the older gem versions.
 
 ```ruby
 require 'rubygems/commands/uninstall_command'

--- a/docs/usage/execution.md
+++ b/docs/usage/execution.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Execution Blocks
-nav_order: 2
+nav_order: 3
 has_children: true
 parent: Usage
 ---

--- a/docs/usage/execution/otherwise.md
+++ b/docs/usage/execution/otherwise.md
@@ -9,7 +9,7 @@ grand_parent: Usage
 
 
 # Otherwise
-The otherwise property is the automation code that is executed when a rule is triggered and guards are not satisfied.  This property accepts a block of code and executes it. The block is automatically passed an event object which can be used to access multiple properties about the triggering event. 
+The otherwise property is the automation code that is executed when a rule is triggered and guards are not satisfied.  This property accepts a block of code and executes it. The block is automatically passed an event object which can be used to access multiple properties about the triggering event.
 
 ## Event Properties
 

--- a/docs/usage/guards.md
+++ b/docs/usage/guards.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Guards
-nav_order: 3
+nav_order: 4
 has_children: true
 parent: Usage
 ---
@@ -20,8 +20,6 @@ Truthyness for Item types:
 | Dimmer     | state != 0         |
 | String     | Not Blank          |
 
-
-
 ## Guard Combination
 
 only_if and not_if can be used on the same rule, both be satisfied for a rule to execute.
@@ -37,6 +35,7 @@ end
 
 
 #### Guard Event Access
+
 Guards have access to event information.
 
 ```ruby

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -5,7 +5,7 @@ nav_order: 4
 has_children: true
 ---
 
+# Rules Requirements
 
-## Rules Requirements
 1. Place Ruby rules files in `ruby/personal/` subdirectory for OpenHAB scripted automation.  See [OpenHAB documentation](https://www.openhab.org/docs/configuration/jsr223.html#script-locations) for parent directory location.
 2. Put `require 'openhab'` at the top of any Ruby based rules file.

--- a/docs/usage/items.md
+++ b/docs/usage/items.md
@@ -1,16 +1,16 @@
 ---
 layout: default
 title: Items
-nav_order: 4
+nav_order: 5
 has_children: true
 parent: Usage
 ---
 
-
 # Items
+
 Items can be directly accessed, compared, etc, without any special accessors. You may use the item name anywhere within the code and it will automatically be loaded.
 
-All items can be accessed as an enumerable the `items` method. 
+All items can be accessed as an enumerable using the `items` method. 
 
 | Method             | Description                                                                    |
 |--------------------|--------------------------------------------------------------------------------|
@@ -24,7 +24,6 @@ Item Definition
 ```
 Dimmer DimmerTest "Test Dimmer"
 Switch SwitchTest "Test Switch"
-
 ```
 
 ```ruby

--- a/docs/usage/items/groups.md
+++ b/docs/usage/items/groups.md
@@ -15,12 +15,12 @@ A group can be accessed directly by name, to access all groups use the `groups` 
 
 ## Group Methods
 
-| Method             | Description                                                                                     |
-| ------------------ | ----------------------------------------------------------------------------------------------- |
-| members            | Used to inform a rule that you want it to operate on the items in the group (see example below) |
+| Method             | Description                                                                                                                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| members            | Used to inform a rule that you want it to operate on the items in the group (see example below)                                                                                                                          |
 | all_members        | Gets all descendants of the group recursively excluding groups. Pass :all as argument to include groups as well, or :groups to only get the sub groups. It's also possible to pass a block to make more advanced filters |
-| each               | Iterates through the members of the group and execute the code in the provided block for each member |
-| enumerable methods | All methods [here](https://ruby-doc.org/core-2.6.8/Enumerable.html)                             |
+| each               | Iterates through the members of the group and execute the code in the provided block for each member                                                                                                                     |
+| enumerable methods | All methods [here](https://ruby-doc.org/core-2.6.8/Enumerable.html)                                                                                                                                                      |
 
 ## Use in triggers
 

--- a/docs/usage/misc.md
+++ b/docs/usage/misc.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Misc
-nav_order: 6
+nav_order: 8
 has_children: true
 parent: Usage
 ---

--- a/docs/usage/misc/duration.md
+++ b/docs/usage/misc/duration.md
@@ -8,13 +8,14 @@ grand_parent: Usage
 ---
 
 # Duration
+
 Ruby [integers](https://ruby-doc.org/core-2.6.8/Integer.html) and
 [floats](https://ruby-doc.org/core-2.6.8/Float.html) are extended with several
 methods to support durations. These methods create a new
 [java.time.Duration](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html)
-object that is used by the [Every trigger](../../triggers/every/),
-[delay](../../execution/delay/), the [for option](../../triggers/changed/) and
-[timers](../../misc/timers/). 
+object that is used by the [Every trigger]({% link usage/triggers/every.md %}),
+[delay]({%link usage/execution/delay.md %}), the [for option]({% link usage/triggers/changed.md %}) and
+[timers]({% link usage/misc/timers.md %}). 
 
 ## Extended Methods
 

--- a/docs/usage/misc/persistence.md
+++ b/docs/usage/misc/persistence.md
@@ -28,9 +28,9 @@ grand_parent: Usage
 | `updated_since`   | timestamp, service                    | boolean                     |                                                                 |
 | `variance_since`  | timestamp, service                    | DecimalType or QuantityType |                                                                 |
 
-* The `timestamp` parameter accepts a java ZonedDateTime or a [Duration](../duration/) object that specifies how far back in time.
+* The `timestamp` parameter accepts a java ZonedDateTime or a [Duration]({% link usage/misc/duration.md %}) object that specifies how far back in time.
 * The `service` optional parameter accepts the name of the persistence service to use, as a String or Symbol. When not specified, the system's default persistence service will be used.
-* Dimensioned NumberItems will return a [QuantityType](../../items/number/#quantities) object
+* Dimensioned NumberItems will return a [QuantityType]({% link usage/items/number.md %}#quantities) object
 * `HistoricState` holds the item state and the timestamp data from OpenHAB's [HistoricItem](https://openhab.org/javadoc/latest/org/openhab/core/persistence/historicitem). It contains the following properties:
   * `timestamp` - a ZonedDateTime object indicating the timestamp of the persisted data
   * `state` - the state of the item persisted at the timestamp above. This will be a QuantityType for dimensioned NumberItem. It is not necessary to access the `state` property, as the HistoricState itself will return the state. See the example below.

--- a/docs/usage/misc/shared_code.md
+++ b/docs/usage/misc/shared_code.md
@@ -11,7 +11,7 @@ grand_parent: Usage
 
 If you would like to easily share code among multiple rules files, you can
 place it in `<OPENHAB_CONF>/automation/lib/ruby/personal`. Assuming `$RUBYLIB`
-is set up correctly in `jruby.conf` (see [Installation](../../../installation)),
+is set up correctly in `jruby.conf` (see [Installation]({% link installation/index.md%})),
 you can then simply `require` the file from your rules files. Because the
 library files _aren't_ in the `jsr223` directory, they won't be automatically
 loaded individually by OpenHAB, only when you `require` them.

--- a/docs/usage/rule.md
+++ b/docs/usage/rule.md
@@ -6,8 +6,8 @@ has_children: false
 parent: Usage
 ---
 
+# Rule Syntax
 
-##  Rule Syntax
 ```ruby
 require 'openhab'
 
@@ -18,7 +18,7 @@ rule 'name' do |<rule>|
 end
 ```
 
-### All of the properties that are available to the rule resource are
+## All of the properties that are available to the rule resource are
 
 | Property         | Type                                                                    | Last/Multiple | Options                               | Default | Description                                                                 | Examples                                                                                                                                                                                                              |
 | ---------------- | ----------------------------------------------------------------------- | ------------- | ------------------------------------- | ------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/usage/things.md
+++ b/docs/usage/things.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Things
-nav_order: 5
+nav_order: 6
 has_children: false
 parent: Usage
 has_toc: false

--- a/docs/usage/things.md
+++ b/docs/usage/things.md
@@ -31,7 +31,7 @@ things['mqtt:topic:4'].uid.bridge_ids => []
 
 The standard [JRuby alternate names and bean convention applies](https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#alternative-names-and-beans-convention), such that `getUID` becomes `uid`.
 
-Actions are available via thing objects. For more details see [Actions](../misc/actions/)
+Actions are available via thing objects. For more details see [Actions]({% link usage/misc/actions.md %})
 
 Thing status is available through `status` method, which returns one of the values from [ThingStatus](https://www.openhab.org/docs/concepts/things.html#thing-status). Boolean methods are available based on this. 
 

--- a/docs/usage/triggers.md
+++ b/docs/usage/triggers.md
@@ -6,17 +6,19 @@ has_children: true
 parent: Usage
 ---
 
-# Trigger Attachments
+# Triggers
+
+Triggers specify what will cause the execution blocks to run. Multiple triggers can be defined within the same rule. This section only applies to file-based rules. Triggers for UI-based rules are specified through the UI.
+
+## Trigger Attachments
 
 All triggers support event attachments that enable the association of an object to a trigger.
 
 | Method | Description                   | example                       |
-|--------|-------------------------------|-------------------------------|
+| ------ | ----------------------------- | ----------------------------- |
 | attach | attach an object to a trigger | changed Switch, attach: 'foo' |
 
-This enables one to use the same rule and take different actions if the trigger is different. 
-
-The attached object is then available on the event object with by the 'attachment' accessor.
+This enables one to use the same rule and take different actions if the trigger is different. The attached object is passed to the execution block through the `event.attachment` accessor.
 
 Note: The trigger attachment feature is not available for UI rules.
 
@@ -29,4 +31,3 @@ rule 'Set Dark switch at sunrise and sunset' do
   run { |event| Dark << event.attachment }
 end
 ```
-

--- a/docs/usage/triggers.md
+++ b/docs/usage/triggers.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Triggers
-nav_order: 1
+nav_order: 2
 has_children: true
 parent: Usage
 ---
@@ -17,6 +17,8 @@ All triggers support event attachments that enable the association of an object 
 This enables one to use the same rule and take different actions if the trigger is different. 
 
 The attached object is then available on the event object with by the 'attachment' accessor.
+
+Note: The trigger attachment feature is not available for UI rules.
 
 ## Example
 

--- a/docs/usage/triggers/changed.md
+++ b/docs/usage/triggers/changed.md
@@ -1,31 +1,39 @@
 ---
 layout: default
 title: Changed
-nav_order: 3
+nav_order: 1
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
+# changed
 
-# Changed
+Execute the rule when an `item`, `group`, `member of group`, or `thing` changed state.
 
+**Syntax:**
 
-| Options | Description                                               | Examples                          |
-| ------- | --------------------------------------------------------- | --------------------------------- |
-| from    | Only execute rule if previous state matches from state(s) | `from: OFF` or `from: 4..9`       |
-| to      | Only execute rule if new state matches to state(s)        | `to: ON` or `to: ->t { t.even? }` |
-| for     | Only execute rule if value stays changed for duration     | `for: 10.seconds`                 |
+```ruby
+changed entity [from:] [to:] [for:]
+```
 
-Changed accepts Items, Things or Groups. 
-To and from accept arrays to match multiple states
+| Options  | Description                                                                                          | Examples                                             |
+| -------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `entity` | One or more item, group, member of group, or thing to monitor for changes                            | `changed SwitchItem1`<br/>`changed Switches.members` |
+| `from:`  | Optional: Only execute rule if previous state matches from state(s)                                  | `from: OFF` or `from: 4..9`                          |
+| `to:`    | Optional: Only execute rule if new state matches to state(s)                                         | `to: ON` or `to: ->t { t.even? }`                    |
+| `for:`   | Optional: Only execute rule if value stays changed for [duration]({% link usage/misc/duration.md %}) | `for: 10.seconds`                                    |
 
 The `from` and `to` options are enhanced compared to the rules DSL:
-1. If the changed element being used as a trigger is a thing, the `to` and `from` values will accept symbols and strings, where the symbol matches the [supported status](https://www.openhab.org/docs/concepts/things.html)
-2. Support for ranges
-3. Support for [procs/lambdas](https://ruby-doc.org/core-2.6/Proc.html) for complex state matches
 
-The for parameter provides a method of only executing the rule if the value is changed for a specific duration.  This provides a built-in method of only executing a rule if a condition is true for a period of time without the need to create dummy objects with the expire binding or make or manage your own timers.
+1. `from` and `to` accept arrays to match multiple states.
+2. If the changed element being used as a trigger is a thing, the `to` and `from` values will accept symbols and strings, where the symbol matches the [supported status](https://www.openhab.org/docs/concepts/things.html#thing-status)
+3. Support for ranges
+4. Support for [procs/lambdas](https://ruby-doc.org/core-2.6/Proc.html) for complex state matches
+
+The for parameter provides a method of only executing the rule if the value is changed for a specific duration.
+This provides a built-in method of only executing a rule if a condition is true for a period of time without the
+need to create dummy objects with the expire binding or make or manage your own timers.
 
 For example, the code in [this design pattern](https://community.openhab.org/t/design-pattern-expire-binding-based-timers/32634) becomes (with no need to create the dummy object):
 ```ruby
@@ -35,7 +43,31 @@ rule "Execute rule when item is changed for specified duration" do
 end
 ```
 
-For parameter can be an item, too:
+Multiple items can be separated with a comma:
+```ruby
+rule 'Execute rule when either sensor changed' do
+  changed FrontMotion_Sensor, RearMotion_Sensor
+  run { |event| logger.info("Motion detected by #{event.item.name}") }
+end
+```
+
+Or in an array:
+```ruby
+SENSORS = [FrontMotion_Sensor, RearMotion_Sensor]
+rule 'Execute rule when either sensor changed' do
+  changed SENSORS
+  run { |event| logger.info("Motion detected by #{event.item.name}") }
+end
+```
+
+Group member trigger:
+```
+rule 'Execute rule when member changed' do
+  changed Sensors.members
+  run { |event| logger.info("Motion detected by #{event.item.name}") }
+end
+```
+`for` parameter can be an item too:
 ```ruby
 Alarm_Delay << 20
 

--- a/docs/usage/triggers/channel.md
+++ b/docs/usage/triggers/channel.md
@@ -9,13 +9,16 @@ grand_parent: Usage
 
 # channel
 
-| Option    | Description                                                                   | Example                                                |
-| --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------ |
-| triggered | Only execute rule if the event on the channel matches this/these event/events | `triggered: 'START' ` or `triggered: ['START','STOP']` |
-| thing     | Thing for specified channels                                                  | `thing: 'astro:sun:home'`                              |
+The channel trigger executes rule when a specific channel is triggered. The syntax supports one or more channels with one or more triggers.
+`thing` is an optional parameter that makes it easier to set triggers on multiple channels on the same thing.
 
-The channel trigger executes rule when a specific channel is triggered.  The syntax supports one or more channels with one or more triggers.   For `thing` is an optional parameter that makes it easier to set triggers on multiple channels on the same thing.
+| Option       | Description                                                                   | Example                                                |
+| ------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `triggered:` | Only execute rule if the event on the channel matches this/these event/events | `triggered: 'START' ` or `triggered: ['START','STOP']` |
+| `thing:`     | Thing for specified channels                                                  | `thing: 'astro:sun:home'`                              |
 
+
+## Examples
 
 ```ruby
 rule 'Execute rule when channel is triggered' do

--- a/docs/usage/triggers/command.md
+++ b/docs/usage/triggers/command.md
@@ -1,20 +1,27 @@
 ---
 layout: default
 title: Received Command
-nav_order: 5
+nav_order: 3
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
+# received_command
 
-# Received_Command
+Execute the rule when an `item`, `group`, or `member of group` received a command.
 
+**Syntax:**
 
-| Options  | Description                                                          | Example                                  |
-| -------- | -------------------------------------------------------------------- | ---------------------------------------- |
-| command  | Only execute rule if the command matches this/these command/commands | `command: 7` or  `command: ->c {c.odd?}` |
-| commands | Alias of command, may be used if matching more than one command      | `commands: [7,14]` or  `commands: 7..14` |
+```ruby
+received_command entity [command:]
+```
+
+| Options     | Description                                                                      | Example                                  |
+| ----------- | -------------------------------------------------------------------------------- | ---------------------------------------- |
+| `entity`    | One or more item, group, or member of group. Multiple entities can be specified. | `received_command SwitchItem1`           |
+| `command:`  | Only execute rule if the command matches this/these command/commands             | `command: 7` or  `command: ->c {c.odd?}` |
+| `commands:` | Alias of command, may be used if matching more than one command                  | `commands: [7,14]` or  `commands: 7..14` |
 
 The `command` or `commands` option restricts the rule from running only if the command matches the supplied arguments
 1. The `command` or `commands` option supports an array of commands

--- a/docs/usage/triggers/cron.md
+++ b/docs/usage/triggers/cron.md
@@ -1,15 +1,17 @@
 ---
 layout: default
 title: Cron
-nav_order: 2
+nav_order: 4
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
+# cron
 
-# Cron
-Utilizes [OpenHAB style cron expressions](https://www.openhab.org/docs/configuration/rules-dsl.html#time-based-triggers) to trigger rules.  This property can be utilized when you need to represent complex expressions not possible with the simpler [every](#Every) syntax.
+Utilizes [OpenHAB style cron expressions](https://www.openhab.org/docs/configuration/rules-dsl.html#time-based-triggers) to trigger rules.  This property can be utilized when you need to represent complex expressions not possible with the simpler [every]({% link usage/triggers/every.md %}) syntax.
+
+## Example
 
 ```ruby
 rule 'Using Cron Syntax' do

--- a/docs/usage/triggers/every.md
+++ b/docs/usage/triggers/every.md
@@ -1,39 +1,45 @@
 ---
 layout: default
 title: Every
-nav_order: 1
+nav_order: 5
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
-# Every
+# every
+
+A simplified cron trigger with human-readable syntax.
 
 | Value             | Description                              | Example    |
 | ----------------- | ---------------------------------------- | ---------- |
-| :second           | Execute rule every second                | :second    |
-| :minute           | Execute rule very minute                 | :minute    |
-| :hour             | Execute rule every hour                  | :hour      |
-| :day              | Execute rule every day                   | :day       |
-| :week             | Execute rule every week                  | :week      |
-| :month            | Execute rule every month                 | :month     |
-| :year             | Execute rule one a year                  | :year      |
-| :monday           | Execute rule every Monday at midnight    | :monday    |
-| :tuesday          | Execute rule every Tuesday at midnight   | :tuesday   |
-| :wednesday        | Execute rule every Wednesday at midnight | :wednesday |
-| :thursday         | Execute rule every Thursday at midnight  | :thursday  |
-| :friday           | Execute rule every Friday at midnight    | :friday    |
-| :saturday         | Execute rule every Saturday at midnight  | :saturday  |
-| :sunday           | Execute rule every Sunday at midnight    | :sunday    |
-| [Integer].seconds | Execute a rule every X seconds           | 5.seconds  |
-| [Integer].minutes | Execute rule every X minutes             | 3.minutes  |
-| [Integer].hours   | Execute rule every X minutes             | 10.hours   |
+| `:second`         | Execute rule every second                | :second    |
+| `:minute`         | Execute rule very minute                 | :minute    |
+| `:hour`           | Execute rule every hour                  | :hour      |
+| `:day`            | Execute rule every day                   | :day       |
+| `:week`           | Execute rule every week                  | :week      |
+| `:month`          | Execute rule every month                 | :month     |
+| `:year`           | Execute rule one a year                  | :year      |
+| `:monday`         | Execute rule every Monday at midnight    | :monday    |
+| `:monday`         | Execute rule every Monday at midnight    | :monday    |
+| `:tuesday`        | Execute rule every Tuesday at midnight   | :tuesday   |
+| `:wednesday`      | Execute rule every Wednesday at midnight | :wednesday |
+| `:thursday`       | Execute rule every Thursday at midnight  | :thursday  |
+| `:friday`         | Execute rule every Friday at midnight    | :friday    |
+| `:saturday`       | Execute rule every Saturday at midnight  | :saturday  |
+| `:sunday`         | Execute rule every Sunday at midnight    | :sunday    |
+| [Numeric].seconds | Execute a rule every X seconds           | 5.seconds  |
+| [Numeric].minutes | Execute rule every X minutes             | 3.minutes  |
+| [Numeric].hours   | Execute rule every X minutes             | 10.hours   |
 
-| Option | Description                                                                                          | Example                                        |
-| ------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| :at    | Limit the execution to specific times of day. The value can either be a String or a TimeOfDay object | at: '16:45' or at: TimeOfDay.new(h: 16, m: 45) |
+| Option | Description                                                                                                                                  | Example                                        |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `:at`  | Limit the execution to specific times of day. The value can either be a String or a [TimeOfDay]({% link usage/misc/time_of_day.md %}) object | at: '16:45' or at: TimeOfDay.new(h: 16, m: 45) |
 
-# Examples
+Note: The `[Numeric].seconds` specifies a [Duration]({% link usage/misc/duration.md %}) / interval. 
+A floating point can also be used to specify a fractional unit of time, e.g. `1.5.hours`
+
+## Examples
 
 ```ruby
 rule 'Log the rule name every minute' do |rule|

--- a/docs/usage/triggers/generic.md
+++ b/docs/usage/triggers/generic.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: Generic Trigger
-nav_order: 7
+nav_order: 9
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
-# Trigger
+# trigger
 
 `trigger` provides the ability to create a trigger type not already covered by the other methods.
 

--- a/docs/usage/triggers/on_start.md
+++ b/docs/usage/triggers/on_start.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: On Start
+nav_order: 7
+has_children: false
+parent: Triggers
+grand_parent: Usage
+---
+
+# on_start
+
+Execute the rule on OpenHAB start up and whenever the script is reloaded.
+It is useful to perform initialization routines, especially when combined with other triggers.
+
+## Examples
+
+```ruby
+rule 'Ensure all security lights are on' do
+  on_start
+  run { Security_Lights << ON }
+end
+```

--- a/docs/usage/triggers/updated.md
+++ b/docs/usage/triggers/updated.md
@@ -1,21 +1,25 @@
 ---
 layout: default
 title: Updated
-nav_order: 4
+nav_order: 2
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
-# Updated 
+# updated 
 
+Execute the rule when the state of an `item`, `group`, `members of group`, or `thing` is updated.
 
+**Syntax:**
+```ruby
+updated <entity> [to:]
+```
 
-| Options | Description                                        | Example                                                       |
-| ------- | -------------------------------------------------- | ------------------------------------------------------------- |
-| to      | Only execute rule if update state matches to state | `to: 7` or `to: [7,14]` or `to: 7..14`  or `to: ->t {t.odd?}` |
-
-Changed accepts Items, Things or Groups. 
+| Options  | Description                                                               | Example                                                       |
+| -------- | ------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `entity` | One or more item, group, member of group, or thing to monitor for updates | `updated SwitchItem1`<br/>`updated Switches.members`          |
+| `to:`    | Only execute rule if update state matches to state                        | `to: 7` or `to: [7,14]` or `to: 7..14`  or `to: ->t {t.odd?}` |
 
 The `to` option restricts the rule from running only if the updated state matches.
 

--- a/docs/usage/triggers/watch.md
+++ b/docs/usage/triggers/watch.md
@@ -1,21 +1,21 @@
 ---
 layout: default
 title: Watch Trigger
-nav_order: 11
+nav_order: 8
 has_children: false
 parent: Triggers
 grand_parent: Usage
 ---
 
-# Watch
+# watch
 
 `watch` provides the ability to create a trigger on file and directory changes
 
-| argument      | Description                                                                                                   |
-| ------------- | ------------------------------------------------------------------------------------------------------------- |
-|               | Path to watch for changes, can be a directory or a file                                                       |
-| glob:         | Limit events to paths matching this glob. Globs are matched using [File.fnmatch?](https://ruby-doc.org/core-2.6/File.html#method-c-fnmatch-3F) rules |
-| for:          | Array of symbols to limit events to only specific change types, valid values are :created, :deleted, :modified |  
+| argument | Description                                                                                                                                          |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          | Path to watch for changes, can be a directory or a file                                                                                              |
+| glob:    | Limit events to paths matching this glob. Globs are matched using [File.fnmatch?](https://ruby-doc.org/core-2.6/File.html#method-c-fnmatch-3F) rules |
+| for:     | Array of symbols to limit events to only specific change types, valid values are :created, :deleted, :modified                                       |
 
 
 If a file or a path that does not exist is supplied as the argument to watch, the parent directory will be watched and the file or non-existent part of the supplied path will become the glob. For example, if the directory given is `/tmp/foo/bar` and `/tmp/foo` exists but `bar` does not exist inside of of `/tmp/foo` then the directory `/tmp/foo` will be watched for any files that match `*/bar`. 
@@ -28,11 +28,11 @@ In other words, `watch '/tmp/foo/*bar'` is equivalent to `watch '/tmp/foo', glob
 ## Event
 
 When an event is triggered to a rule, the event object has the following fields
-| field         | Description                                                                                                                 |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| path          | Ruby [Pathname](https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html) object of the path that had an event  |
-| type          | Type of changes as a symbol, valid values are :created, :deleted, or :modified                                              | 
-| attachment    | Attachment if supplied                                                                                                      |
+| field      | Description                                                                                                                |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| path       | Ruby [Pathname](https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html) object of the path that had an event |
+| type       | Type of changes as a symbol, valid values are :created, :deleted, or :modified                                             |
+| attachment | Attachment if supplied                                                                                                     |
 
 
 

--- a/docs/usage/ui-rules.md
+++ b/docs/usage/ui-rules.md
@@ -1,60 +1,80 @@
 ---
 layout: default
-title: Creating rules in the UI
-nav_order: 2
+title: Creating Rules in the UI
+nav_order: 7
 has_children: false
 parent: Usage
 ---
 
-## Creating rules in Main UI ##
+# Creating Rules in Main UI
 
 Rules can be created in the UI as well as in rules files, but some things are a bit different.
-First of all only the execution blocks need to be created in the script. All triggers and conditions
+First of all, only the execution blocks need to be created in the script. All triggers and conditions
 are created directly in the UI instead.
 
-To create a rule:
+**To create a rule:**
+
 1. Go to the Rules section in the UI and add a new rule.
-2. Input a name for your rule, and configure the Triggers (note that only the predefined triggers are available,
-the specializations the script library adds, such as the `every` trigger cannot be used)
+2. Input a name for your rule, and configure the Triggers through the UI.
 3. When adding an Action, select **Run script**, and then **Ruby**. A script editor will open where you can write your code.
-4. When you are done, save the script and go back to complete the configuration
+4. When you are done, save the script and go back to complete the configuration.
 
-To make all the extras available to your rule, the first line should be `require 'openhab'`. This will enable
-all the special methods for Items, Things, Actions, Logging etc. that are documented here, and the event properties
-documented for the Run execution block.
+## UI Rules vs File-based Rules
 
-Note that the Delay, Triggered, and Otherwise Execution blocks cannot be used, but the same functionality can be
-acheived in other ways. E.g instead of `delay 5.seconds` you can use `sleep 5` which causes the script to pause
-for 5 seconds, or you can use timers like in the example below. Otherwise can be implemented with an `if-else` block. Guards can't be used either, but similar functionality can be achieved through Conditions.
+The following features of this library are only usable within file-based rules:
 
-## Examples ##
+* `Triggers`: UI-based rules provide equivalent triggers through the UI.
+* `Guards`: UI-based rules use `Conditions` in the UI instead. Alternatively it can be implemented inside the rule code.
+* `Execution Blocks`: The UI-based rules will execute your JRuby script as if it's inside a `run` execution block. 
+A special `event` variable is available within your code to provide it with additional information regarding the event. 
+For more details see the [run execution block](../execution/run/).
+* `delay`: There is no direct equivalent in the UI. It can be achieved using timers like in the example below.
+* `otherwise`: There is no direct equivalent in the UI. However, it can be implemented within the rule using an `if-else` block.
 
-Reset the switch that triggered the rule after 5 seconds
+## Loading the Scripting Library
+
+To make all the features offered by this library available to your rule, the JRuby scripting addon needs to
+be [configured](../../installation/#from-the-user-interface) to install the `openhab-scripting` gem and
+require the `openhab` script. This will enable all the special methods for [Items](../items/),
+[Things](../things/), [Actions](../misc/actions/), [Logging](../logging/) etc. that are documented here,
+and the `event` properties documented for the [Run execution block](../execution/run/).
+
+## Examples
+
+### Reset the switch that triggered the rule after 5 seconds
 
 Trigger defined as:
-- When: a member of an item group recieves a command
+
+- When: a member of an item group receives a command
 - Group: Reset_5Seconds
 - Command: ON
 
 ```ruby
-require 'openhab'
-
 logger.info("#{event.item.id} Triggered the rule")
 after 5.seconds do
   event.item << OFF
 end
 ```
 
-Update a DateTime Item with the current time when a motion sensor is triggered
+### Update a DateTime Item with the current time when a motion sensor is triggered
+
+Given the following group and items:
+```
+Group MotionSensors
+Switch Sensor1 (MotionSensors)
+Switch Sensor2 (MotionSensors)
+
+DateTime Sensor1_LastMotion
+DateTime Sensor2_LastMotion
+```
 
 Trigger defined as:
+
 - When: the state of a member of an item group is updated
 - Group: MotionSensors
 - State: ON
 
 ```ruby
-require 'openhab'
-
 logger.info("#{event.item.id} Triggered")
 items["#{event.item_name}_LastMotion"].update Time.now
 ```

--- a/docs/usage/ui-rules.md
+++ b/docs/usage/ui-rules.md
@@ -27,17 +27,17 @@ The following features of this library are only usable within file-based rules:
 * `Guards`: UI-based rules use `Conditions` in the UI instead. Alternatively it can be implemented inside the rule code.
 * `Execution Blocks`: The UI-based rules will execute your JRuby script as if it's inside a `run` execution block. 
 A special `event` variable is available within your code to provide it with additional information regarding the event. 
-For more details see the [run execution block](../execution/run/).
+For more details see the [run execution block]({% link usage/execution/run.md %}).
 * `delay`: There is no direct equivalent in the UI. It can be achieved using timers like in the example below.
 * `otherwise`: There is no direct equivalent in the UI. However, it can be implemented within the rule using an `if-else` block.
 
 ## Loading the Scripting Library
 
 To make all the features offered by this library available to your rule, the JRuby scripting addon needs to
-be [configured](../../installation/#from-the-user-interface) to install the `openhab-scripting` gem and
-require the `openhab` script. This will enable all the special methods for [Items](../items/),
-[Things](../things/), [Actions](../misc/actions/), [Logging](../logging/) etc. that are documented here,
-and the `event` properties documented for the [Run execution block](../execution/run/).
+be [configured]({% link usage/items.md %}#from-the-user-interface) to install the `openhab-scripting` gem and
+require the `openhab` script. This will enable all the special methods for [Items]({% link usage/items.md %}),
+[Things]({% link usage/things.md %}), [Actions]({% link usage/misc/actions.md %}), [Logging]({% link usage/misc/logging.md %}) etc. that are documented here,
+and the `event` properties documented for the [Run execution block]({% link usage/execution/run.md %}).
 
 ## Examples
 


### PR DESCRIPTION
This contains multiple commits.

* Specify a local theme for jekyll so `rake docs:jekyll` pulls the correct template. This enables me to review the changes locally.
* Update the UI usage page
* Change the links to use Jekyll's `link` tag. With `rake docs:jekyll` running, we can immediately see if whether the links are valid.
* Rearrange and tidy up the triggers section
* Add on_start into the triggers section

It's getting harder to arrange the multiple commits and split the changes into logical smaller commits, so I'd just stop here.