### PR TITLE
test: improve test reliability on openhab 3.3

### DIFF
--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -46,13 +46,13 @@ namespace :openhab do
   def ready?(fail_on_error: false)
     return unless running?
 
-    if fail_on_error
-      fail_on_error("#{@karaf_client} 'system:version'")
-      true
-    else
-      cmd = TTY::Command.new(:printer => :null)
-      cmd.run!("#{@karaf_client} 'system:version'").success?
-    end
+    command = "#{@karaf_client} 'system:start-level'"
+
+    cmd = TTY::Command.new(:printer => :null)
+    ready = cmd.run!(command).out.chomp.casecmp?('Level 100')
+    raise 'OpenHAB is not ready' if !ready && fail_on_error
+
+    ready
   end
 
   def ensure_openhab_running


### PR DESCRIPTION
See #548 

* Check for system start level for openhab's readiness. This should address the issue when Rest requests sometimes hit a 404 because openhab's rest bundle isn't loaded yet.
* Restore the optimized openhab client, except when doing feature:install. This seems to save about 5 minutes off the test time.
* when not using the optimized client, call cmd.run! which doesn't raise an exception on error. This allows wait_until to keep retrying even after encountering (temporary) errors.

Note: feature:install openhab-binding-systeminfo caused openhab to restart on 3.3.0.m2