### PR TITLE
feat(item_equality): add the ability to compare item objects

### DIFF
--- a/docs/usage/misc/comparisons.md
+++ b/docs/usage/misc/comparisons.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Type Comparisons
+title: Comparisons
 nav_order: 12
 has_children: false
 parent: Misc
@@ -9,7 +9,36 @@ grand_parent: Usage
 
 # Item and State Type Comparisons
 
-Some OpenHAB item types can accept different command types. For example, a Dimmer item can accept a command with an `OnOffType`, `IncreaseDecreaseType` or a `PercentType`. However, ultimately an item only stores its state in its native type, e.g. a Dimmer item's native type is PercentType.
+Comparison of two items implicitly compares their states. For example:
+
+```ruby
+if Item1 == Item2
+  logger.info('The state of Item1 is the same as the state of Item2')
+end
+```
+
+Comparing the actual items can be achieved using `#item` method of either operand:
+
+```ruby
+Item1.item == items['Item1'].item   # This would always return true
+Item1.item == Item2.item            # This would always return false
+
+# When Item1, Item2 and Item3 all have the same state:
+[Item1, Item2].include?(Item3.item) # => false - Check for the existence of Item3 inside the array
+[Item1, Item2].include?(Item3)      # => true - State check
+```
+
+Using `#item` is not necessary for hash keys because Hash keys are indexed by their hash codes.
+
+```ruby
+# When Item1 and Item2 contain the same state:
+hash = { Item1 => 'value1', Item2 => 'value2' }
+hash[Item2] # => 'value2' this will correctly match Item2's value in the hash
+```
+
+Some OpenHAB item types can accept different command types. For example, a Dimmer item can accept a command 
+with an `OnOffType`, `IncreaseDecreaseType` or a `PercentType`. However, ultimately an item only stores its 
+state in its native type, e.g. a Dimmer item's native type is PercentType.
 
 ## Loose Type Comparisons
 

--- a/docs/usage/misc/comparisons.md
+++ b/docs/usage/misc/comparisons.md
@@ -9,38 +9,103 @@ grand_parent: Usage
 
 # Item and State Type Comparisons
 
-Comparison of two items implicitly compares their states. For example:
+Comparisons of items implicitly compare the states. 
 
 ```ruby
-if Item1 == Item2
-  logger.info('The state of Item1 is the same as the state of Item2')
-end
-```
-
-Comparing the actual items can be achieved using `#item` method of either operand:
-
-```ruby
-Item1.item == items['Item1'].item   # This would always return true
-Item1.item == Item2.item            # This would always return false
-
 # When Item1, Item2 and Item3 all have the same state:
-[Item1, Item2].include?(Item3.item) # => false - Check for the existence of Item3 inside the array
-[Item1, Item2].include?(Item3)      # => true - State check
+
+# State comparison
+Item1 == Item2                      # => true - when they both have the same state
+Item1 == items['Item2']             # => true - same as above
+
+Item1 == ON                         # => true if Item1's state is ON
+ON == Item1                         # => true if Item1's state is ON
+
+case Item1
+when OFF then logger.info('Item1 is OFF')
+when ON then logger.info('Item1 is ON')
+end
+
+NumberItem1 > 5                     # Item can be compared against numbers
+Outside_Temp > '24 °C'              # with Units of Measurement
+StringItem1 == 'single'             # or string
+DateItem1 < Time.now                # or date/time
+DateItem1 < '2022-01-01'            # datetime against string
 ```
 
-Using `#item` is not necessary for hash keys because Hash keys are indexed by their hash codes.
+## Item Comparisons
+
+To compare item objects, use the `#item` method on either item:
 
 ```ruby
-# When Item1 and Item2 contain the same state:
-hash = { Item1 => 'value1', Item2 => 'value2' }
-hash[Item2] # => 'value2' this will correctly match Item2's value in the hash
+# When Item1, Item2 and Item3 all have the same state:
+
+# Item comparison
+Item1 == Item2.item                 # => false - different items
+Item1 == items['Item2'].item        # => false - different items
+Item1 == items['Item1'].item        # => true - same item
+# Using eql?
+Item1.eql?(Item2)                   # => false - different items
+Item1.eql?(items['Item1'])          # => true - same item
+
+# Case statement. Given Item1, Item2 and Item3 are OFF
+result =  case Item1                # => 'off' 
+          when OFF then 'off'       #   OFF === Item1 is true, first match
+          when Item2 then 'i2'
+          when Item1 then 'i1'
+          end
+
+result =  case Item1.item           # => 'i1' 
+          when OFF then 'off'       #   OFF === Item1.item   => false
+          when Item2 then 'i2'      #   Item2 === Item1.item => false
+          when Item1 then 'i1'      #   Item1 === Item1.item => true
+          end
 ```
+
+### Items within Hashes, Arrays and Groups
+
+Using `#item` is needed for `Array#include?` and `Hash#value?`, but not necessary for hash keys or `grep`:
+
+```ruby
+# Given that:
+# Item1, Item2 and Item2 contain the same state
+# Item1 and Item2 belong to Group12 group
+# Item3 doesn't belong to Group12 group
+
+# Arrays and Group #include? will compare against the given item's state
+[Item1, Item2].include?(Item3)        # => true - array has item(s) whose state match Item3's state
+[Item1, Item2].include?(Item3.state)  # => true - same as above 
+
+# To check for the actual item, use .item
+[Item1, Item2].include?(Item3.item)   # => false - now we're checking for the item object
+
+Group12.include?(Item3)               # => true - Item3 is not in the group but its state matches
+Group12.include?(Item3.item)          # => false - now we're checking for the actual item
+
+# GOTCHA: Hash keys and grep operate on the item itself, not its state
+hash = { Item1 => 'value1', Item2 => 'value2' }
+hash[Item3]                           # => nil - this will look up the item
+hash[Item2]                           # => 'value2' - this will look up the item
+hash[Item2.item]                      # => 'value2' - we can use an explicit .item
+
+[Item1, Item2].grep(Item3)            # => [] - grep also looks up the item, not the state
+[Item1, Item2].grep(Item3.item)       # => [] - we can use an explicit .item 
+[Item1, Item2].grep(Item3.state)      # => [Item1, Item2] - same state as Item3's state
+```
+
+-----
+> **In summary:** To avoid ambiguity, use the item's `#item` method whenever the item's object needs to be matched.
+
+-----
+
+
+## Type Comparisons
 
 Some OpenHAB item types can accept different command types. For example, a Dimmer item can accept a command 
 with an `OnOffType`, `IncreaseDecreaseType` or a `PercentType`. However, ultimately an item only stores its 
 state in its native type, e.g. a Dimmer item's native type is PercentType.
 
-## Loose Type Comparisons
+## Loose Type-Comparisons
 
 Comparisons between two compatible types will return true when applicable, for example:
 
@@ -71,7 +136,7 @@ end
 DimmerItem1 << 100 # => This will trigger the logger.info above
 ```
 
-### Bypassing Loose Type Comparisons
+### Bypassing Loose Type-Comparisons
 
 If at any point you want to bypass loose type conversions, use `eql?`. Just be aware that this also bypasses the implicit conversion of an Item to its state.
 
@@ -85,7 +150,7 @@ logger.error DimmerItem1.state.eql?(10) # => false
 logger.error DimmerItem1.state.eql?(PercentType.new(10)) # => true
 ```
 
-## Strict Type Comparisons
+## Strict Type-Comparisons
 
 Sometimes it is critical to know the exact command being sent. For example, a rule may need to distinguish between `ON` vs. a `PercentType` command. In this instance, Ruby's case equality operator `===` can be used. It will only evaluate to true if the two operands have the same type.
 

--- a/features/items.feature
+++ b/features/items.feature
@@ -383,4 +383,22 @@ Feature:  items
     And It should log "Same Item object comparison 2: true" within 5 seconds
     And It should log "Same Item object comparison 3: true" within 5 seconds
 
+  Scenario: GroupItem grep can use Item.item
+    Given group "Switches"
+    And items:
+      | type   | name    | group    | state |
+      | Switch | Switch1 | Switches | OFF   |
+      | Switch | Switch2 | Switches | OFF   |
+    And a rule:
+      """
+      logger.info "grep result1: #{Switches.grep(Switch1.item).first.name}"
+      logger.info "grep result2: #{Switches.grep(Switch2.item).first.name}"
+      logger.info "grep result3: #{Switches.grep(Switch1).first.name}"
+      logger.info "grep result4: #{Switches.grep(Switch2).first.name}"
+      """
+    When I deploy the rule
+    Then It should log "grep result1: Switch1" within 5 seconds
+    And It should log "grep result2: Switch2" within 5 seconds
+    And It should log "grep result3: Switch1" within 5 seconds
+    And It should log "grep result4: Switch2" within 5 seconds
 

--- a/features/items.feature
+++ b/features/items.feature
@@ -311,3 +311,76 @@ Feature:  items
     And item 'MySwitch' state is changed to 'ON'
     Then It should log "Label: bar" within 5 seconds
 
+  Scenario: Item objects can be compared in a case statement
+    Given a rule:
+      """
+      logger.info case SwitchTwo.item
+                  when DimmerTest then 'Matched DimmerTest'
+                  when SwitchTest then 'Matched SwitchTest'
+                  when SwitchTwo then 'Matched SwitchTwo'
+                  end
+      """
+    When item 'DimmerTest' state is changed to '0'
+    And I deploy the rule
+    Then It should log "Matched SwitchTwo" within 5 seconds
+
+  Scenario: Items matches array#include?
+    Given a rule:
+      """
+      logger.info("SwitchTwo in array? #{[DimmerTest, SwitchTwo].include?(SwitchTwo.item)}")
+      logger.info("DimmerTest in array? #{[SwitchTwo, SwitchTest].include?(DimmerTest.item)}")
+      logger.info("SwitchTest in array? #{[DimmerTest, SwitchTwo].include?(SwitchTest.item)}")
+      """
+    When item 'DimmerTest' state is changed to '0'
+    And I deploy the rule
+    Then It should log "SwitchTwo in array? true" within 5 seconds
+    And It should log "DimmerTest in array? false" within 5 seconds
+    And It should log "SwitchTest in array? false" within 5 seconds
+
+  Scenario: Items matches hash#key?
+    Given a rule:
+      """
+      logger.info("SwitchTwo in hash? #{{DimmerTest => true, SwitchTwo => true}.key?(SwitchTwo)}")
+      logger.info("SwitchTwo.item in hash? #{{DimmerTest => true, SwitchTwo => true}.key?(SwitchTwo.item)}")
+      logger.info("DimmerTest in hash? #{{SwitchTwo => true, SwitchTest => true}.key?(DimmerTest)}")
+      logger.info("SwitchTest in hash? #{{DimmerTest => true, SwitchTwo => true}.key?(SwitchTest)}")
+      """
+    When item 'DimmerTest' state is changed to '0'
+    And I deploy the rule
+    Then It should log "SwitchTwo in hash? true" within 5 seconds
+    And It should log "SwitchTwo.item in hash? true" within 5 seconds
+    And It should log "DimmerTest in hash? false" within 5 seconds
+    And It should log "SwitchTest in hash? false" within 5 seconds
+
+  Scenario: Items matches hash#value?
+    Given a rule:
+      """
+      logger.info("SwitchTwo in value? #{{a: DimmerTest, b: SwitchTwo}.value?(SwitchTwo.item)}")
+      logger.info("DimmerTest in value? #{{a: SwitchTwo, b: SwitchTest}.value?(DimmerTest.item)}")
+      logger.info("SwitchTest in value? #{{a: DimmerTest, b: SwitchTwo}.value?(SwitchTest.item)}")
+      """
+    When item 'DimmerTest' state is changed to '0'
+    And I deploy the rule
+    Then It should log "SwitchTwo in value? true" within 5 seconds
+    And It should log "DimmerTest in value? false" within 5 seconds
+    And It should log "SwitchTest in value? false" within 5 seconds
+
+  Scenario: Direct comparison of Items
+    Given a rule:
+      """
+      logger.info("State comparison: #{SwitchTwo == SwitchTest}")
+      logger.info("Different Item objects comparison1: #{SwitchTwo.item == SwitchTest.item}")
+      logger.info("Different Item objects comparison2: #{SwitchTwo.item == SwitchTest}")
+      logger.info("Same Item object comparison 1: #{SwitchTwo.item == items['SwitchTwo'].item}")
+      logger.info("Same Item object comparison 2: #{SwitchTwo == items['SwitchTwo'].item}")
+      logger.info("Same Item object comparison 3: #{SwitchTwo.item == items['SwitchTwo']}")
+      """
+    When I deploy the rule
+    Then It should log "State comparison: true" within 5 seconds
+    And It should log "Different Item objects comparison1: false" within 5 seconds
+    And It should log "Different Item objects comparison2: false" within 5 seconds
+    And It should log "Same Item object comparison 1: true" within 5 seconds
+    And It should log "Same Item object comparison 2: true" within 5 seconds
+    And It should log "Same Item object comparison 3: true" within 5 seconds
+
+

--- a/lib/openhab/dsl/items/item_equality.rb
+++ b/lib/openhab/dsl/items/item_equality.rb
@@ -22,13 +22,28 @@ module OpenHAB
         # @return [Boolean]
         #
         def ==(other)
-          logger.trace("(#{self.class}) #{self} == #{other} (#{other.class})")
+          logger.trace("ItemEquality#== (#{self.class}) #{self} == #{other} (#{other.class})")
+          return eql?(other) if generic_item_object?(other)
           return true if equal?(other) || eql?(other)
           return true if !state? && other.nil?
 
           return raw_state == other.raw_state if other.is_a?(GenericItem)
 
           state == other
+        end
+
+        private
+
+        #
+        # Determines if an object equality check is required, based on whether
+        # either operand is a GenericItemObject
+        #
+        # @param [Object] other
+        #
+        # @return [Boolean]
+        #
+        def generic_item_object?(other)
+          other.is_a?(OpenHAB::DSL::GenericItemObject) || is_a?(OpenHAB::DSL::GenericItemObject)
         end
       end
     end

--- a/lib/openhab/dsl/items/item_equality.rb
+++ b/lib/openhab/dsl/items/item_equality.rb
@@ -22,7 +22,7 @@ module OpenHAB
         # @return [Boolean]
         #
         def ==(other)
-          logger.trace("ItemEquality#== (#{self.class}) #{self} == #{other} (#{other.class})")
+          logger.trace { "ItemEquality#== (#{self.class}) #{self} == #{other} (#{other.class})" }
           return eql?(other) if generic_item_object?(other)
           return true if equal?(other) || eql?(other)
           return true if !state? && other.nil?
@@ -30,6 +30,14 @@ module OpenHAB
           return raw_state == other.raw_state if other.is_a?(GenericItem)
 
           state == other
+        end
+
+        #
+        # Check item object equality for grep
+        #
+        def ===(other)
+          logger.trace { "ItemEquality#=== (#{self.class}) #{self} == #{other} (#{other.class})" }
+          eql?(other)
         end
 
         private

--- a/lib/openhab/dsl/types/point_type.rb
+++ b/lib/openhab/dsl/types/point_type.rb
@@ -57,7 +57,7 @@ module OpenHAB
         # @return [Boolean]
         #
         def ==(other) # rubocop:disable Metrics
-          logger.trace("(#{self.class}) #{self} == #{other} (#{other.class})")
+          logger.trace { "(#{self.class}) #{self} == #{other} (#{other.class})" }
           if other.is_a?(Items::LocationItem) ||
              (other.is_a?(Items::GroupItem) && other.base_item.is_a?(LocationItem))
             return false unless other.state?

--- a/lib/openhab/dsl/types/type.rb
+++ b/lib/openhab/dsl/types/type.rb
@@ -48,8 +48,8 @@ module OpenHAB
         #                   or item state of the same type
         #
         def ===(other)
-          logger.trace("(#{self.class}) #{self} === #{other} (#{other.class})")
-          other = other.state if other.respond_to?(:state)
+          logger.trace { "Type (#{self.class}) #{self} === #{other} (#{other.class})" }
+          other = other.state if other.respond_to?(:state) && !other.is_a?(OpenHAB::DSL::GenericItemObject)
           return false unless instance_of?(other.class)
 
           eql?(other)
@@ -62,7 +62,7 @@ module OpenHAB
         #   type conversions
         #
         def ==(other) # rubocop:disable Metrics
-          logger.trace("(#{self.class}) #{self} == #{other} (#{other.class})")
+          logger.trace { "(#{self.class}) #{self} == #{other} (#{other.class})" }
           return true if equal?(other)
 
           # i.e. ON == OFF, REFRESH == ON, ON == REFRESH


### PR DESCRIPTION
Fix #541 

* Add GenericItem#item method that returns GenericItemObject
* ItemEquality #== uses `eql?` when its argument is a GenericItemObject, i.e. `ItemName.item`
* This means users can use ItemName.item to ensure that they are operating on the item, not the state for equality comparison purposes
* Add ItemEquality #=== so that grep operates on the item without needing `.item`
* Update comparisons.md doc to clarify this issue
