### PR TITLE
docs(theme): make remote_theme work locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,7 @@ group :development do
   gem 'tty-command'
   gem 'yard'
 end
+
+group :jekyll_plugins do
+  gem 'jekyll-remote-theme'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,11 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
@@ -197,6 +202,7 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -245,6 +251,7 @@ DEPENDENCIES
   guard-yard
   httparty
   jekyll (~> 4.2)
+  jekyll-remote-theme
   just-the-docs (~> 0.3)
   kramdown-parser-gfm
   openhab-scripting!

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,7 +28,6 @@ exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "pac
 # Build settings
 markdown: kramdown
 remote_theme: pmarsceill/just-the-docs
-theme: just-the-docs
 plugins:
   - jekyll-feed
 


### PR DESCRIPTION
As it turns out, adding `theme:` into jekyll's _config.yml broke the github page deployment.

This PR removed the `theme:` and make `remote_theme` to work locally by installing the jekyll-remote-theme gem in Gemfile.

Re-run bundle install to install it.