### PR TITLE
feat(cron): support fields for cron and monthday object for every

### DIFF
--- a/docs/usage/triggers/cron.md
+++ b/docs/usage/triggers/cron.md
@@ -9,9 +9,13 @@ grand_parent: Usage
 
 # cron
 
-Utilizes [OpenHAB style cron expressions](https://www.openhab.org/docs/configuration/rules-dsl.html#time-based-triggers) to trigger rules.  This property can be utilized when you need to represent complex expressions not possible with the simpler [every]({{ site.baseurl }}{% link usage/triggers/every.md %}) syntax.
+There are three ways of creating a cron trigger:
 
-## Example
+* Using an [OpenHAB style cron expression](https://www.openhab.org/docs/configuration/rules-dsl.html#time-based-triggers) 
+* Specifying each cron field as named arguments
+* Using a simpler [every]({{ site.baseurl }}{% link usage/triggers/every.md %}) syntax
+
+## Using a cron expression
 
 ```ruby
 rule 'Using Cron Syntax' do
@@ -19,3 +23,35 @@ rule 'Using Cron Syntax' do
   run { logger.info "Cron rule executed" }
 end
 ```
+
+## Using cron fields
+
+Cron Field Names
+
+| Field     | Description                                      |
+| --------- | ------------------------------------------------ |
+| `second:` | Defaults to `0` when not specified               |
+| `minute:` | Defaults to `0` when not specified               |
+| `hour:`   | Defaults to `0` when not specified               |
+| `dom:`    | Day of month. Defaults to `?` when not specified |
+| `month:`  | Defaults to `*` when not specified               |
+| `dow:`    | Day of week. Defaults to `?` when not specified  |
+| `year:`   | Defaults to `*` when not specified               |
+
+Each field is optional, but at least one must be specified. The same rules for the standard [cron expression](https://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/tutorial-lesson-06.html) 
+apply for each field.
+For example, multiple values can be separated with a comma within a string. Omitted fields will default to `*` or `?` 
+as applicable.
+
+```ruby
+# Run every 3 minutes on Monday to Friday
+# equivalent to the cron expression '0 */3 * ? * MON-FRI *'
+rule 'Using cron fields' do
+  cron second: 0, minute: '*/3', dow: 'MON-FRI'
+  run { logger.info "Cron rule executed" }
+end
+```
+
+## Using Every syntax
+
+See: [every]({{ site.baseurl }}{% link usage/triggers/every.md %})

--- a/docs/usage/triggers/every.md
+++ b/docs/usage/triggers/every.md
@@ -9,28 +9,29 @@ grand_parent: Usage
 
 # every
 
-A simplified cron trigger with human-readable syntax.
+A simplified [cron]({{ site.baseurl }}{% link usage/triggers/cron.md %}) trigger with human-readable syntax.
 
-| Value             | Description                              | Example    |
-| ----------------- | ---------------------------------------- | ---------- |
-| `:second`         | Execute rule every second                | :second    |
-| `:minute`         | Execute rule very minute                 | :minute    |
-| `:hour`           | Execute rule every hour                  | :hour      |
-| `:day`            | Execute rule every day                   | :day       |
-| `:week`           | Execute rule every week                  | :week      |
-| `:month`          | Execute rule every month                 | :month     |
-| `:year`           | Execute rule one a year                  | :year      |
-| `:monday`         | Execute rule every Monday at midnight    | :monday    |
-| `:monday`         | Execute rule every Monday at midnight    | :monday    |
-| `:tuesday`        | Execute rule every Tuesday at midnight   | :tuesday   |
-| `:wednesday`      | Execute rule every Wednesday at midnight | :wednesday |
-| `:thursday`       | Execute rule every Thursday at midnight  | :thursday  |
-| `:friday`         | Execute rule every Friday at midnight    | :friday    |
-| `:saturday`       | Execute rule every Saturday at midnight  | :saturday  |
-| `:sunday`         | Execute rule every Sunday at midnight    | :sunday    |
-| [Numeric].seconds | Execute a rule every X seconds           | 5.seconds  |
-| [Numeric].minutes | Execute rule every X minutes             | 3.minutes  |
-| [Numeric].hours   | Execute rule every X minutes             | 10.hours   |
+| Value               | Description                                                                                           | Example                        |
+| ------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `:second`           | Execute rule every second                                                                             | `:second`                      |
+| `:minute`           | Execute rule every minute                                                                             | `:minute`                      |
+| `:hour`             | Execute rule every hour                                                                               | `:hour`                        |
+| `:day`              | Execute rule every day                                                                                | `:day`                         |
+| `:week`             | Execute rule every week (on Monday)                                                                   | `:week`                        |
+| `:month`            | Execute rule every month                                                                              | `:month`                       |
+| `:year`             | Execute rule once a year                                                                              | `:year`                        |
+| `:monday`           | Execute rule every Monday at midnight                                                                 | `:monday`                      |
+| `:monday`           | Execute rule every Monday at midnight                                                                 | `:monday`                      |
+| `:tuesday`          | Execute rule every Tuesday at midnight                                                                | `:tuesday`                     |
+| `:wednesday`        | Execute rule every Wednesday at midnight                                                              | `:wednesday`                   |
+| `:thursday`         | Execute rule every Thursday at midnight                                                               | `:thursday`                    |
+| `:friday`           | Execute rule every Friday at midnight                                                                 | `:friday`                      |
+| `:saturday`         | Execute rule every Saturday at midnight                                                               | `:saturday`                    |
+| `:sunday`           | Execute rule every Sunday at midnight                                                                 | `:sunday`                      |
+| `[Numeric].seconds` | Execute rule every X seconds                                                                          | `5.seconds`                    |
+| `[Numeric].minutes` | Execute rule every X minutes                                                                          | `3.minutes`, `1.5.minutes`     |
+| `[Numeric].hours`   | Execute rule every X hours                                                                            | `10.hours`                     |
+| `MonthDay`          | Execute rule at midnight on the given MonthDay. The value can either be a MonthDay object or a String | `MonthDay.of(3,14)`, `'03-14'` |
 
 | Option | Description                                                                                                                                                    | Example                                        |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -74,5 +75,12 @@ end
 rule 'Every 5 seconds' do |rule|
   every 5.seconds
   run { logger.info "Rule #{rule.name} executed" }
+end
+```
+
+```ruby
+rule 'Every 14th of Feb at 2pm' do 
+  every '02-14', at: '2pm'
+  run { logger.info "Happy Valentine's Day!" }
 end
 ```

--- a/features/cron.feature
+++ b/features/cron.feature
@@ -18,3 +18,17 @@ Feature:  cron
       """
     When I deploy the rule
     Then It should log 'Cron rule executed' within 15 seconds
+
+  Scenario: Cron can use specifiers
+    Given a rule
+      """
+      schedule = Time.now + 5
+
+      rule 'Using Cron Syntax' do
+        cron second: schedule.sec, minute: schedule.min
+        run { logger.info "Cron rule executed" }
+      end
+      """
+    When I deploy the rule
+    Then It should not log 'Cron rule executed' within 3 seconds
+    And It should log 'Cron rule executed' within 10 seconds


### PR DESCRIPTION
* Support using MonthDay for every, e.g. `every MonthDay.of(12, 25)` and `every '12-25'`
* Support using field names for cron, e.g.`cron second: 0, minute: 10, hour: 15, dow: 'MON,TUE,FRI'`
* Correct some typos in the corresponding docs

Previously I'd have to use a guard with every because it cannot be restricted to a specific monthday, resulting in the trigger firing every day at a specific time. By accepting monthday, the cron trigger can fire just once on the desired monthday.

The field names on cron makes it easier to remember. I normally had to look up the cron docs every time even though I'm only interested in certain fields.

