### PR TITLE
feat(states): add state? helper method

### DIFF
--- a/docs/usage/misc/state.md
+++ b/docs/usage/misc/state.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: Valid State
+has_children: false
+parent: Misc
+grand_parent: Usage
+---
+
+# state?
+
+`state?` returns true if all the given items have a valid state (not UNDEF or NULL).
+
+| Parameter | Description                                                                                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `items`   | One or more items to check                                                                                                                                               |
+| `things:` | Default: `false` - do not check for linked things status. When `things:` is set to `true`, only return true when all things linked to the items are in the ONLINE state. |
+
+## Examples
+
+```ruby
+if state? Item1, Item2 
+  average = (Item1 + Item2)/2 # Neither Item1 nor Item2 is UNDEF/NULL
+end
+```
+
+or in a rule guard
+
+```ruby
+rule 'calculate' do
+  changed Item1, Item2
+  only_if { state? Item1, Item2 }
+  run { logger.info "Average of Item1 and Item2: #{(Item1 + Item2) / 2}}" }
+end
+```
+
+It can take an array of items:
+
+```ruby
+calculated_items = [ Item1, Item2 ]
+
+rule 'calculate' do
+  changed calculated_items
+  only_if { state? calculated_items }
+  run { logger.info "Sum of Item1 and Item2: #{calculated_items.sum}" }
+end
+```

--- a/docs/usage/misc/store_states.md
+++ b/docs/usage/misc/store_states.md
@@ -7,7 +7,7 @@ parent: Misc
 grand_parent: Usage
 ---
 
-### store_states
+# store_states
 
 store_states takes one or more items or groups and returns a map `{Item => State}` with the current state of each item. It is implemented by calling OpenHAB's [events.storeStates()](https://www.openhab.org/docs/configuration/actions.html#event-bus-actions).
 
@@ -39,4 +39,4 @@ The returned states variable is a hash that supports some additional methods:
 | --------------- | ---------------------------------------------------------------------------------------- |
 | restore         | Restores the states of all the stored items by calling events.restoreStates() internally |
 | changed?        | Returns true if any of the stored items had changed states                               |
-| restore_changes | restores only items whose state had changed    
+| restore_changes | restores only items whose state had changed                                              |

--- a/features/states.feature
+++ b/features/states.feature
@@ -1,35 +1,97 @@
 Feature:  states
-    Rule languages supports storing and restoring states
+  Rule languages supports states processing
 
-    Background:
-        Given Clean OpenHAB with latest Ruby Libraries
-        And items:
-            | type   | name    | label             | state |
-            | Switch | Switch1 | Switch Number One | OFF   |
-            | Switch | Switch2 | Switch Number Two | OFF   |
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
+    And items:
+      | type   | name    | label             | state |
+      | Switch | Switch1 | Switch Number One | OFF   |
+      | Switch | Switch2 | Switch Number Two | OFF   |
 
+  Scenario: States can be stored and restored using store_states
+    Given code in a rules file:
+      """
+      states = store_states Switch1, Switch2
+      Switch1 << ON
+      after(5.seconds) { states.restore }
+      """
+    When I deploy the rule
+    Then "Switch1" should be in state "ON" within 2 seconds
+    But If I wait 5 seconds
+    Then "Switch1" should be in state "OFF" within 2 seconds
 
-    Scenario: States can be stored and restored using store_states
-        Given code in a rules file:
-            """
-            states = store_states Switch1, Switch2
-            Switch1 << ON
-            after(5.seconds) { states.restore }
-            """
-        When I deploy the rule
-        Then "Switch1" should be in state "ON" within 2 seconds
-        But If I wait 5 seconds
-        Then "Switch1" should be in state "OFF" within 2 seconds
+  Scenario: States can be stored and restored using store_states block
+    Given code in a rules file:
+      """
+      store_states Switch1, Switch2 do
+        Switch1 << ON
+        sleep 5
+      end
+      """
+    When I start deploying the rule
+    Then "Switch1" should be in state "ON" within 2 seconds
+    But If I wait 5 seconds
+    Then "Switch1" should be in state "OFF" within 2 seconds
 
-    Scenario: States can be stored and restored using store_states block
-        Given code in a rules file:
-            """
-            store_states Switch1, Switch2 do
-              Switch1 << ON
-              sleep 5
-            end
-            """
-        When I start deploying the rule
-        Then "Switch1" should be in state "ON" within 2 seconds
-        But If I wait 5 seconds
-        Then "Switch1" should be in state "OFF" within 2 seconds
+  Scenario Outline: Check item states
+    Given code in a rules file:
+      """
+      Switch1.update <state>
+      sleep 0.5
+      if state? Switch1, Switch2
+        logger.info "All items have a valid state"
+      else
+        logger.info "Some states are nil"
+      end
+      """
+    When I start deploying the rule
+    Then It <should> log "All items have a valid state" within 3 seconds
+    And It <should_not> log "Some states are nil" within 3 seconds
+    Examples:
+      | state | should     | should_not |
+      | ON    | should     | should not |
+      | UNDEF | should not | should     |
+      | NULL  | should not | should     |
+
+  Scenario Outline: Check item states before executing a rule
+    Given code in a rules file:
+      """
+      Switch1.update <state>
+      sleep 0.5
+      rule 'state check' do
+        on_start
+        only_if { state? Switch1, Switch2 }
+        run { logger.info "All items have a valid state" }
+      end
+      """
+    When I deploy the rule
+    Then It <should> log "All items have a valid state" within 3 seconds
+    Examples:
+      | state | should     |
+      | ON    | should     |
+      | UNDEF | should not |
+      | NULL  | should not |
+
+  Scenario Outline: Check item states and their thing status
+    Given feature 'openhab-binding-astro' installed
+    And things:
+      | id   | thing_uid | label          | config                | status  |
+      | home | astro:sun | Astro Sun Data | {"geolocation":"0,0"} | <state> |
+    And items:
+      | type   | name          |
+      | Number | Sun_Elevation |
+    And linked:
+      | item          | channel                           |
+      | Sun_Elevation | astro:sun:home:position#elevation |
+    And a rule:
+      """
+      Sun_Elevation.update 0
+      sleep 0.2
+      logger.info "Sun_Elevation is valid? #{state? Sun_Elevation, things: true}"
+      """
+    When I deploy the rule
+    Then It should log "Sun_Elevation is valid? <result>" within 5 seconds
+    Examples:
+      | state   | result |
+      | enable  | true   |
+      | disable | false  |

--- a/lib/openhab/dsl/states.rb
+++ b/lib/openhab/dsl/states.rb
@@ -28,6 +28,18 @@ module OpenHAB
         end
         states
       end
+
+      #
+      # Check if all the given items have a state (not UNDEF or NULL)
+      #
+      # @param [Array] items whose state must be non-nil
+      # @param [<Type>] check_things when true, also ensures that all linked things are online
+      #
+      # @return [Boolean] true if all the items have a state, false otherwise
+      #
+      def state?(*items, things: false)
+        items.flatten.all? { |item| (!things || item.things.all?(&:online?)) && item.state? }
+      end
     end
 
     module Support


### PR DESCRIPTION

# state?

`state?` returns true if all the given items have a valid state (not UNDEF or NULL).

| Parameter       | Description                                                                                                                                                                    |
| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `items`         | One or more items to check                                                                                                                                                     |
| `things:` | Default: `false` - do not check for linked things status. When `things:` is set to `true`, only return true when all things linked to the items are in the ONLINE state. |


```ruby
if state? Item1, Item2 
  average = (Item1 + Item2)/2 # Neither Item1 nor Item2 is UNDEF/NULL
end
```

or in a rule guard

```ruby
rule 'calculate' do
  changed Item1, Item2
  only_if { state? Item1, Item2 }
  run { logger.info "Average of Item1 and Item2: #{(Item1 + Item2) / 2}}" }
end
```

It can take an array of items:

```ruby
calculated_items = [ Item1, Item2 ]

rule 'calculate' do
  changed calculated_items
  only_if { state? calculated_items }
  run { logger.info "Sum of Item1 and Item2: #{calculated_items.sum}" }
end
```

A possible solution to #460 although this doesn't automatically capture the dependencies from the triggers, but it is usable in a normal code, not just tied to a rule structure.

