### PR TITLE
feat: add support for timer and persistence to accept zoneddatetime and rubytime

### DIFF
--- a/docs/usage/misc/duration.md
+++ b/docs/usage/misc/duration.md
@@ -19,12 +19,12 @@ object that is used by the [Every trigger]({{ site.baseurl }}{% link usage/trigg
 
 ## Extended Methods
 
-| Method                                      | Description                    |
-| ------------------------------------------- | ------------------------------ |
-| hour or hours                               | Convert number to hours        |
-| minute or minutes                           | Convert number to minutes      |
-| second or seconds                           | Convert number to seconds      |
-| millis or millisecond or milliseconds or ms | Convert number to milliseconds |
+| Method                                              | Description                    | Examples              |
+| --------------------------------------------------- | ------------------------------ | --------------------- |
+| `hour` or `hours`                                   | Convert number to hours        | `1.hour`, `2.5 hours` |
+| `minute` or `minutes`                               | Convert number to minutes      | `3.minutes`           |
+| `second` or `seconds`                               | Convert number to seconds      | `5.seconds`           |
+| `millis` or `millisecond` or `milliseconds` or `ms` | Convert number to milliseconds | `200.ms`              |
 
 
 ## Examples

--- a/docs/usage/misc/persistence.md
+++ b/docs/usage/misc/persistence.md
@@ -28,7 +28,7 @@ grand_parent: Usage
 | `updated_since`   | timestamp, service                    | boolean                     |                                                                 |
 | `variance_since`  | timestamp, service                    | DecimalType or QuantityType |                                                                 |
 
-* The `timestamp` parameter accepts a java ZonedDateTime or a [Duration]({{ site.baseurl }}{% link usage/misc/duration.md %}) object that specifies how far back in time.
+* The `timestamp` parameter accepts a java ZonedDateTime, a Ruby [Time](https://ruby-doc.org/core-2.6.3/Time.html), or a [Duration]({{ site.baseurl }}{% link usage/misc/duration.md %}) object that specifies how far back in time.
 * The `service` optional parameter accepts the name of the persistence service to use, as a String or Symbol. When not specified, the system's default persistence service will be used.
 * Dimensioned NumberItems will return a [QuantityType]({{ site.baseurl }}{% link usage/items/number.md %}#quantities) object
 * `HistoricState` holds the item state and the timestamp data from OpenHAB's [HistoricItem](https://openhab.org/javadoc/latest/org/openhab/core/persistence/historicitem). It contains the following properties:

--- a/docs/usage/misc/timers.md
+++ b/docs/usage/misc/timers.md
@@ -9,17 +9,17 @@ grand_parent: Usage
 
 # Timers
 
-Timers are created using the `after` method.
+Timers are created using the `after` method. `create_timer` is an alias to `after` for compatibility reasons.
 
 After method parameters
 
-| Parameter | Description                                                        |
-| --------- | ------------------------------------------------------------------ |
-| duration  | Duration for timer                                                 |
-| id        | Optional object that is used to identify the timer                 |
-| block     | Block to execute after duration, block will be passed timer object |
+| Parameter | Description                                                                                                                                                          |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| time      | Accepts a [Duration]({{ site.baseurl }}{% link usage/misc/duration.md %}), Ruby [Time](https://ruby-doc.org/core-2.6.3/Time.html), or Java `ZonedDateTime` for timer |
+| id        | Optional object that is used to identify the timer                                                                                                                   |
+| block     | Block to execute after duration, block will be passed timer object                                                                                                   |
 
-Timers with an id are reentrant, by id and block. Reentrant means that when the same id and block are encountered the timer is resheduled rather than creating a second new timer.
+Timers with an id are reentrant, by id and block. Reentrant means that when the same id and block are encountered the timer is rescheduled rather than creating a second new timer.
 
 ## Timer Object
 

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -121,6 +121,30 @@ Feature: persistence
     Then It should log 'Average: 3' within 10 seconds
     And It should log 'Average Max: 3' within 10 seconds
 
+  Scenario: Persistence support various time arguments
+    Given items:
+      | type   | name         | label | state |
+      | Number | Number_Power | Power | 10    |
+
+    And code in a rules file:
+      """
+      rule 'update persistence' do
+        on_start
+        run { Number_Power.update 3 }
+        delay 5.second
+        run do
+          logger.info("Max: #{Number_Power.maximum_since(<time>, :mapdb)}")
+        end
+      end
+      """
+    When I deploy the rule
+    Then It should log 'Max: 3' within 10 seconds
+    Examples:
+      | time                               |
+      | 3.seconds                          |
+      | ZonedDateTime.now.minus_seconds(3) |
+      | Time.now - 3                       |
+
   Scenario: Check that HistoricState directly returns a state
     Given items:
       | type         | name         | label | pattern | state |

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -40,6 +40,32 @@ Feature:  timer
     But if I wait 3 seconds
     Then It should log 'Timer Fired' within 5 seconds
 
+  Scenario: Timers support ZonedDateTime
+    Given code in a rules file
+      """
+      java_import java.time.ZonedDateTime # this import is not needed on OH 3.3+
+
+      after ZonedDateTime.now.plus_seconds(3) do
+        logger.info("Timer Fired")
+      end
+      """
+    When I deploy the rules file
+    Then It should not log 'Timer Fired' within 1 seconds
+    But if I wait 3 seconds
+    Then It should log 'Timer Fired' within 5 seconds
+
+  Scenario: Timers support Ruby Time
+    Given code in a rules file
+      """
+      after Time.now + 3 do
+        logger.info("Timer Fired")
+      end
+      """
+    When I deploy the rules file
+    Then It should not log 'Timer Fired' within 1 seconds
+    But if I wait 3 seconds
+    Then It should log 'Timer Fired' within 5 seconds
+
   Scenario: Timers support number items
     Given items:
       | type   | name       | label      | state   |
@@ -124,7 +150,6 @@ Feature:  timer
       """
     When I deploy the rules file
     Then It should log 'Timer is active? true' within 5 seconds
-
 
   Scenario: Timers can be rescheduled
     Given code in a rules file

--- a/lib/openhab/dsl/items/persistence.rb
+++ b/lib/openhab/dsl/items/persistence.rb
@@ -76,19 +76,15 @@ module OpenHAB
         private
 
         #
-        # Convert timestamp to ZonedDateTime if it's a TemporalAmount
+        # Convert timestamp to ZonedDateTime with duration negated to indicate a time in the past
         #
-        # @param [Object] timestamp to convert
+        # @param [Object] timestamp timestamp to convert
         #
         # @return [ZonedDateTime]
         #
         def to_zdt(timestamp)
-          if timestamp.is_a? Java::JavaTimeTemporal::TemporalAmount
-            logger.trace("Converting #{timestamp} (#{timestamp.class}) to ZonedDateTime")
-            Java::JavaTime::ZonedDateTime.now.minus(timestamp)
-          else
-            timestamp
-          end
+          timestamp = timestamp.negated if timestamp.is_a? Java::JavaTime::Duration
+          OpenHAB::DSL.to_zdt(timestamp)
         end
 
         #


### PR DESCRIPTION
Add support for 

* `after(ZonedDateTime.now.plus_minutes(xx))` (or create_timer)
* `after(Time.now + xx)`
* `Item.persistence_method(Time.now - xxx)`

I needed to use Item.historic_state from a specific date. ZonedDateTime is a bit onerous to use e.g.
```
start_date = ZonedDateTime.of(2021, 12, 23, 0, 0, 0, 0, ZoneId.system_default)
start_value = Item.historic_state(start_date)
```

With this PR I could use `start_date = Time.new(2021, 12, 23)`.