### PR TITLE
fix(zoneddatetime): make ZonedDateTime available on OpenHAB 3.2

### DIFF
--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -741,16 +741,7 @@ Exec.executeCommandLine('/path/to/program')
 
 ### Use ZonedDateTime
 
-Prior to OpenHAB 3.3, ZonedDateTime needs to be imported before use. From OpenHAB 3.3+ the following classes are available without having to import them manually:
-
-* `ZonedDateTime`
-* `ZoneId`
-* `Duration`
-* `ChronoUnit`
-
 ```ruby
-java_import java.time.ZonedDateTime # Not needed on OpenHAB 3.3+
-
 ZonedDateTime.now.plus_minutes(30)
 ```
 

--- a/features/actions.feature
+++ b/features/actions.feature
@@ -22,11 +22,10 @@ Feature:  actions
   Scenario: Exec action is supported
     Given a rule
       """
-      java_import java.time.Duration
       rule 'Execute command line' do
         on_start
         run do
-          output = Exec.executeCommandLine(Duration.ofSeconds(2), '/bin/echo', 'Hello, World!').chomp
+          output = Exec.executeCommandLine(2.seconds, '/bin/echo', 'Hello, World!').chomp
           logger.info("executeCommandLine output: '#{output}'")
         end
       end

--- a/features/date_time_item.feature
+++ b/features/date_time_item.feature
@@ -1,7 +1,7 @@
 Feature: date_time_item
   Rule language supports DateTime Items
 
-    Background:
+  Background:
     Given Clean OpenHAB with latest Ruby Libraries
     And group "Dates"
     And items:
@@ -10,74 +10,74 @@ Feature: date_time_item
       | DateTime | DateTwo   | Date Two   | Dates | 2021-01-31T08:00:00+00:00 |
       | DateTime | DateThree | Date Three | Dates | 2021-01-31T14:00:00+06:00 |
 
-    Scenario Outline: DateTime Items support math operations
-      Given item "DateOne" state is changed to "<initial>"
-      And code in a rules file
-        """
+  Scenario Outline: DateTime Items support math operations
+    Given item "DateOne" state is changed to "<initial>"
+    And code in a rules file
+      """
         DateOne << DateOne<operator> <operand>
-        """
-      When I deploy the rules file
-      Then "DateOne" should be in state "<final>" within 5 seconds
-      Examples:
-        | initial                  | operator | operand    | final                        |
-        | 1970-01-31T08:00:00+0200 | +        | 600        | 1970-01-31T08:10:00.000+0200 |
-        | 1970-01-31T08:00:00+0000 | -        | 600        | 1970-01-31T07:50:00.000+0000 |
-        | 1970-01-31T08:00:00+0000 | +        | '00:05'    | 1970-01-31T08:05:00.000+0000 |
-        | 1970-01-31T08:00:00+0200 | -        | '00:05'    | 1970-01-31T07:55:00.000+0200 |
-        | 1970-01-31T08:00:00+0000 | +        | 20.minutes | 1970-01-31T08:20:00.000+0000 |
-        | 1970-01-31T08:00:00+0000 | -        | 20.minutes | 1970-01-31T07:40:00.000+0000 |
+      """
+    When I deploy the rules file
+    Then "DateOne" should be in state "<final>" within 5 seconds
+    Examples:
+      | initial                  | operator | operand    | final                        |
+      | 1970-01-31T08:00:00+0200 | +        | 600        | 1970-01-31T08:10:00.000+0200 |
+      | 1970-01-31T08:00:00+0000 | -        | 600        | 1970-01-31T07:50:00.000+0000 |
+      | 1970-01-31T08:00:00+0000 | +        | '00:05'    | 1970-01-31T08:05:00.000+0000 |
+      | 1970-01-31T08:00:00+0200 | -        | '00:05'    | 1970-01-31T07:55:00.000+0200 |
+      | 1970-01-31T08:00:00+0000 | +        | 20.minutes | 1970-01-31T08:20:00.000+0000 |
+      | 1970-01-31T08:00:00+0000 | -        | 20.minutes | 1970-01-31T07:40:00.000+0000 |
 
-    Scenario Outline: Ruby Time methods work
-      Given code in a rules file      
-        """
+  Scenario Outline: Ruby Time methods work
+    Given code in a rules file
+      """
         logger.info(DateTwo.<method>)
-        """
-      When I deploy the rules file
-      Then It should log "<result>" within 5 seconds
-      Examples:
-        | method  | result |
-        | sunday? | true   |
-        | monday? | false  |
-        | wday    | 0      |
-        | utc?    | true   |
-        | month   | 1      |
-        | zone    | Z      |
+      """
+    When I deploy the rules file
+    Then It should log "<result>" within 5 seconds
+    Examples:
+      | method  | result |
+      | sunday? | true   |
+      | monday? | false  |
+      | wday    | 0      |
+      | utc?    | true   |
+      | month   | 1      |
+      | zone    | Z      |
 
-    Scenario: Items with same time but different zone should be equal
-      Given code in a rules file
-        """
+  Scenario: Items with same time but different zone should be equal
+    Given code in a rules file
+      """
         if DateTwo == DateThree
           logger.info("Same date")
         end
-        """
-      When I deploy the rules file
-      Then It should log "Same date" within 5 seconds
+      """
+    When I deploy the rules file
+    Then It should log "Same date" within 5 seconds
 
-    Scenario: Items can be updated by ruby Time objects
-      Given code in a rules file
-        """
+  Scenario: Items can be updated by ruby Time objects
+    Given code in a rules file
+      """
         DateOne << Time.at(60 * 60 * 24).utc
-        """
-      When I deploy the rules file
-      Then "DateOne" should be in state "1970-01-02T00:00:00.000+0000" within 5 seconds
+      """
+    When I deploy the rules file
+    Then "DateOne" should be in state "1970-01-02T00:00:00.000+0000" within 5 seconds
 
-    Scenario Outline: Calculating time differences work
-      Given item "DateOne" state is changed to "2021-01-31T09:00:00+00:00"
-      And code in a rules file
-        """
+  Scenario Outline: Calculating time differences work
+    Given item "DateOne" state is changed to "2021-01-31T09:00:00+00:00"
+    And code in a rules file
+      """
         logger.info((DateOne - <operand>).to_i)
-        """
-      When I deploy the rules file
-      Then It should log "<result>" within 5 seconds
-      Examples:
-        | operand                     | result |
-        | '2021-01-31T07:00:00+00:00' | 7200   |
-        | Time.utc(2021, 1, 31, 7)    | 7200   |
-        | DateTwo                     | 3600   |
+      """
+    When I deploy the rules file
+    Then It should log "<result>" within 5 seconds
+    Examples:
+      | operand                     | result |
+      | '2021-01-31T07:00:00+00:00' | 7200   |
+      | Time.utc(2021, 1, 31, 7)    | 7200   |
+      | DateTwo                     | 3600   |
 
-    Scenario: DateTimeItems work with TimeOfDay ranges
-      Given code in a rules file
-        """
+  Scenario: DateTimeItems work with TimeOfDay ranges
+    Given code in a rules file
+      """
         case DateThree
         when between('00:00'...'08:00')
           logger.info('DateThree is between 00:00..08:00')
@@ -86,29 +86,27 @@ Feature: date_time_item
         when between('16:00'..'23:59')
           logger.info('DateThree is between 16:00...23:59')
         end
-        """
-      When I deploy the rules file
-      Then It should log "DateThree is between 08:00..16:00" within 5 seconds
+      """
+    When I deploy the rules file
+    Then It should log "DateThree is between 08:00..16:00" within 5 seconds
 
-    Scenario: between-ranges can be created from DateTimeItems
-      Given code in a rules file
-        """
+  Scenario: between-ranges can be created from DateTimeItems
+    Given code in a rules file
+      """
         if between(DateOne...DateTwo).cover? '05:00'
           logger.info('05:00 is between DateOne..DateTwo')
         end
-        """
-      When I deploy the rules file
-      Then It should log "05:00 is between DateOne..DateTwo" within 5 seconds
+      """
+    When I deploy the rules file
+    Then It should log "05:00 is between DateOne..DateTwo" within 5 seconds
 
-    Scenario: DateTime items accept ZonedDateTime
-      Given code in a rules file
-        """
+  Scenario: DateTime items accept ZonedDateTime
+    Given code in a rules file
+      """
         require 'java'
-        java_import java.time.ZoneId
-        java_import java.time.ZonedDateTime
         DateOne << ZonedDateTime.of(1999,12,31,0,0,0,0,ZoneId.of("UTC"))
-        """
-      When I deploy the rules file
-      Then "DateOne" should be in state "1999-12-31T00:00:00.000+0000" within 5 seconds
+      """
+    When I deploy the rules file
+    Then "DateOne" should be in state "1999-12-31T00:00:00.000+0000" within 5 seconds
 
 

--- a/features/every.feature
+++ b/features/every.feature
@@ -54,7 +54,7 @@ Feature:  every
     Given a rule:
       """
       time = (Time.now + 3).strftime('%H:%M:%S')
-      today = Java::JavaTime::ZonedDateTime.now
+      today = ZonedDateTime.now
 
       def monthday(zdt)
         MonthDay.of(zdt.month_value, zdt.day_of_month)

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -24,7 +24,6 @@ Feature: persistence
   Scenario: Make calls to various Persistence methods
     Given code in a rules file:
       """
-      java_import java.time.ZonedDateTime
       @@last_update = nil
 
       rule 'record updated time' do

--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -234,7 +234,7 @@ Feature: rule_language
       """
     When I deploy the rules file
     Then It should log /Rule UID: '.+'/ within 5 seconds
-    
+
   Scenario: DSL methods don't leak into other objects
     Given a raw rule:
       """

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -43,8 +43,6 @@ Feature:  timer
   Scenario: Timers support ZonedDateTime
     Given code in a rules file
       """
-      java_import java.time.ZonedDateTime # this import is not needed on OH 3.3+
-
       after ZonedDateTime.now.plus_seconds(3) do
         logger.info("Timer Fired")
       end

--- a/lib/openhab/dsl/dsl.rb
+++ b/lib/openhab/dsl/dsl.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'imports'
+
+OpenHAB::DSL.import_presets
+
 require 'openhab/log/logger'
 
 # the order of these is important

--- a/lib/openhab/dsl/imports.rb
+++ b/lib/openhab/dsl/imports.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module DSL
+    include OpenHAB::Log
+    #
+    # Import required java classes
+    #
+    def self.import_presets # rubocop:disable Metrics/AbcSize
+      return if Object.const_get(:ZonedDateTime).is_a?(Class)
+
+      # Fix the import problem in OpenHAB 3.2 addon. Not required in 3.3+
+      [java.time.Duration,
+       java.time.ZonedDateTime,
+       java.time.ZoneId,
+       java.time.temporal.ChronoUnit].each do |klass|
+        Object.const_set(klass.java_class.simple_name.to_sym, klass)
+      end
+    end
+  end
+end

--- a/lib/openhab/dsl/items/timed_command.rb
+++ b/lib/openhab/dsl/items/timed_command.rb
@@ -171,6 +171,7 @@ module OpenHAB
             # rubocop: disable Metrics/AbcSize
             # There is no feasible way to break this method into smaller components
             def execute(_mod = nil, inputs = nil)
+              OpenHAB::DSL.import_presets
               @semaphore.synchronize do
                 thread_local(@thread_locals) do
                   logger.trace "Canceling implicit timer #{@timed_command_details.timer} for "\

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -23,7 +23,6 @@ module OpenHAB
         include OpenHAB::Log
         include OpenHAB::Core::ThreadLocal
         include OpenHAB::DSL::Between
-        java_import java.time.ZonedDateTime
 
         #
         # Create a new Rule
@@ -55,6 +54,7 @@ module OpenHAB
         #
         #
         def execute(mod = nil, inputs = nil)
+          OpenHAB::DSL.import_presets
           thread_local(RULE_NAME: name) do
             logger.trace { "Execute called with mod (#{mod&.to_string}) and inputs (#{inputs.inspect})" }
             logger.trace { "Event details #{inputs['event'].inspect}" } if inputs&.key?('event')

--- a/lib/openhab/dsl/timers/timer.rb
+++ b/lib/openhab/dsl/timers/timer.rb
@@ -9,7 +9,6 @@ require 'openhab/core/thread_local'
 module OpenHAB
   module DSL
     java_import org.openhab.core.model.script.actions.ScriptExecution
-    java_import java.time.ZonedDateTime
 
     # Ruby wrapper for OpenHAB Timer
     # This class implements delegator to delegate methods to the OpenHAB timer
@@ -80,6 +79,7 @@ module OpenHAB
       #
       def timer_block(semaphore)
         proc {
+          OpenHAB::DSL.import_presets
           semaphore.synchronize do
             Timers.timer_manager.delete(self)
             thread_local(@thread_locals) do

--- a/lib/openhab/dsl/types/date_time_type.rb
+++ b/lib/openhab/dsl/types/date_time_type.rb
@@ -8,7 +8,6 @@ module OpenHAB
   module DSL
     module Types
       DateTimeType = org.openhab.core.library.types.DateTimeType
-      java_import java.time.ZonedDateTime # This is needed for the addon prior to ruby_class fix (OH 3.2.0)
 
       # global alias - required for jrubyscripting addon <= OH3.2.0
       ::DateTimeType = DateTimeType if ::DateTimeType.is_a?(Java::JavaLang::Class)


### PR DESCRIPTION
Move the java_import for ZonedDateTime to the top of dsl.rb so it's available for user scripts.
Remove instances of `java_import java.time.ZonedDateTime` in other places

This makes it no longer necessary to import ZonedDateTime within user scripts even on openhab 3.2.
This also deduplicates the multiple imports in submodules.

By "importing", I mean re-assigning the ZonedDateTime constant to the Ruby class version. I'm not sure how "expensive" this operation is, but I suspect it's very "cheap" / fast to execute.
