### PR TITLE
feat(conf): rename __conf__ to OpenHAB.conf_root

### DIFF
--- a/docs/usage/triggers/watch.md
+++ b/docs/usage/triggers/watch.md
@@ -38,11 +38,12 @@ When an event is triggered to a rule, the event object has the following fields
 
 ## Examples
 
- Watch `items` directory inside of the openhab configuration path and log any changes. `__conf__` is available and is the path to the OpenHAB configuration directory as a Ruby pathname object.
+Watch `items` directory inside of the openhab configuration path and log any changes. `OpenHAB.conf_root` is available and is the path 
+to the OpenHAB configuration directory as a Ruby pathname object.
 
 ```ruby
 rule 'watch directory' do
-  watch __conf__/'items'
+  watch OpenHAB.conf_root/'items'
   run { |event| logger.info("#{event.path.basename} - #{event.type}") }
 end
 ```
@@ -50,7 +51,7 @@ end
  Watch `items` directory for files that end in `*.erb` inside of the openhab configuration path and log any changes
 ```ruby
 rule 'watch directory' do
-  watch __conf__/'items', glob: '*.erb'
+  watch OpenHAB.conf_root/'items', glob: '*.erb'
   run { |event| logger.info("#{event.path.basename} - #{event.type}") }
 end
 ```
@@ -58,7 +59,7 @@ end
 Watch `items/foo.items` inside of the openhab configuration path and log any changes
 ```ruby
 rule 'watch directory' do
-  watch __conf__/'items/foo.items'
+  watch OpenHAB.conf_root/'items/foo.items'
   run { |event| logger.info("#{event.path.basename} - #{event.type}") }
 end
 ```
@@ -66,7 +67,7 @@ end
 Watch `items/*.items` inside of the openhab configuration path and log any changes
 ```ruby
 rule 'watch directory' do
-  watch __conf__/'items/*.items'
+  watch OpenHAB.conf_root/'items/*.items'
   run { |event| logger.info("#{event.path.basename} - #{event.type}") }
 end
 ```
@@ -74,7 +75,7 @@ end
 Watch `items/*.items` inside of the openhab configuration path for when items files are deleted or created (ignore changes)
 ```ruby
 rule 'watch directory' do
-  watch __conf__/'items/*.items', for: [:deleted, :created]
+  watch OpenHAB.conf_root/'items/*.items', for: [:deleted, :created]
   run { |event| logger.info("#{event.path.basename} - #{event.type}") }
 end
 ```

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -21,7 +21,7 @@ Feature:  attachments
       end
       """
     When <action>
-    Then It should log 'attachment - <attachment>' within 5 seconds
+    Then It should log 'attachment - <attachment>' within 15 seconds
     Examples: Checks multiple attachments
       | trigger                                                    | attachment | action                                                    |
       | changed Switch1                                            | foo        | item "Switch1" state is changed to "ON"                   |
@@ -32,7 +32,7 @@ Feature:  attachments
       | on_start true                                              | qaz        | I wait 2 seconds                                          |
       | every :second                                              | qux        | I wait 2 seconds                                          |
       | cron five_seconds_from_now                                 | qab        | I wait 5 seconds                                          |
-      | watch __conf__+'foo'                                       | qac        | I create a file in subdirectory 'foo' of conf named 'bar' |
+      | watch OpenHAB.conf_root/'foo'                              | qac        | I create a file in subdirectory 'foo' of conf named 'bar' |
 
 
   Scenario Outline: Guards have access to attachments

--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -217,8 +217,8 @@ Feature: rule_language
   Scenario: OpenHAB config directory is available
     Given code in a rules file:
       """
-        logger.info("Conf #{__conf__}")
-        logger.info("Conf directory is #{__conf__.each_filename.to_a.last(2).join('/')}")
+        logger.info("Conf #{OpenHAB.conf_root}")
+        logger.info("Conf directory is #{OpenHAB.conf_root.each_filename.to_a.last(2).join('/')}")
       """
     When I deploy the rules file
     Then It should log 'Conf directory is openhab/conf' within 5 seconds
@@ -234,7 +234,7 @@ Feature: rule_language
       """
     When I deploy the rules file
     Then It should log /Rule UID: '.+'/ within 5 seconds
-    
+
   Scenario: DSL methods don't leak into other objects
     Given a raw rule:
       """

--- a/features/watch.feature
+++ b/features/watch.feature
@@ -5,23 +5,23 @@ Feature:  watch
   Background:
     Given Clean OpenHAB with latest Ruby Libraries
 
-  Scenario Outline: Watch supports directories 
+  Scenario Outline: Watch supports directories
     Given a file in subdirectory 'foo' of conf named 'bar'
     And a file in subdirectory 'foo' of conf named 'baz'
     And a deployed rule:
       """
       rule 'watch directory' do
-        watch __conf__ + 'foo'
+        watch OpenHAB.conf_root + 'foo'
         run { |event| logger.info("#{event.path.basename} - #{event.type}") }
       end
       """
     When I <action> a file in subdirectory 'foo' of conf named '<file>'
     Then It should log '<log>' within 5 seconds
     Examples:
-      | action | file       | log            |
-      | create | qux        | qux - created  | 
-      | delete | bar        | bar - deleted  | 
-      | modify | baz        | baz - modified | 
+      | action | file | log            |
+      | create | qux  | qux - created  |
+      | delete | bar  | bar - deleted  |
+      | modify | baz  | baz - modified |
 
   Scenario Outline: Watch supports globs
     Given a file in subdirectory 'foo' of conf named 'bar.erb'
@@ -29,20 +29,20 @@ Feature:  watch
     And a deployed rule:
       """
       rule 'watch directory' do
-        watch __conf__/'foo', glob: '*.erb'
+        watch OpenHAB.conf_root/'foo', glob: '*.erb'
         run { |event| logger.info("#{event.path.basename} - #{event.type}") }
       end
       """
     When I <action> a file in subdirectory 'foo' of conf named '<file>'
     Then It <should> log '<log>' within 5 seconds
     Examples:
-      | action | file      | should    | log                |
-      | create | qux.erb   | should    | qux.erb - created  | 
-      | delete | bar.erb   | should    | bar.erb - deleted  | 
-      | modify | baz.erb   | should    | baz.erb - modified | 
-      | create | qux       | should not| qux - created      | 
-      | delete | bar       | should not| qux - deleted      | 
-      | modify | baz       | should not| baz - modified     | 
+      | action | file    | should     | log                |
+      | create | qux.erb | should     | qux.erb - created  |
+      | delete | bar.erb | should     | bar.erb - deleted  |
+      | modify | baz.erb | should     | baz.erb - modified |
+      | create | qux     | should not | qux - created      |
+      | delete | bar     | should not | qux - deleted      |
+      | modify | baz     | should not | baz - modified     |
 
   Scenario Outline: Watch supports a single file
     Given a file in subdirectory 'foo' of conf named 'bar'
@@ -50,34 +50,34 @@ Feature:  watch
     And a deployed rule:
       """
       rule 'watch file' do
-        watch __conf__ + 'foo/bar'
+        watch OpenHAB.conf_root + 'foo/bar'
         run { |event| logger.info("#{event.path.basename} - #{event.type}") }
       end
       """
     When I <action> a file in subdirectory 'foo' of conf named '<file>'
     Then It <should> log '<log>' within 5 seconds
     Examples:
-      | action | file      | should    | log               |
-      | modify | bar       | should    | bar - modified    | 
-      | delete | bar       | should    | bar - deleted     | 
-      | modify | baz       | should not| baz - modified    | 
-      | delete | baz       | should not| baz - deleted     | 
+      | action | file | should     | log            |
+      | modify | bar  | should     | bar - modified |
+      | delete | bar  | should     | bar - deleted  |
+      | modify | baz  | should not | baz - modified |
+      | delete | baz  | should not | baz - deleted  |
 
   Scenario Outline: Watch supports creation for single file
     Given a subdirectory 'foo' of conf
     And a deployed rule:
       """
       rule 'watch file' do
-        watch __conf__ + 'foo/bar'
+        watch OpenHAB.conf_root + 'foo/bar'
         run { |event| logger.info("#{event.path.basename} - #{event.type}") }
       end
       """
     When I <action> a file in subdirectory 'foo' of conf named '<file>'
     Then It <should> log '<log>' within 5 seconds
     Examples:
-      | action | file      | should    | log               |
-      | create | bar       | should    | bar - created     | 
-      | create | baz       | should not| baz - created     | 
+      | action | file | should     | log           |
+      | create | bar  | should     | bar - created |
+      | create | baz  | should not | baz - created |
 
 
   Scenario Outline: Watch supports globs in path
@@ -86,35 +86,35 @@ Feature:  watch
     And a deployed rule:
       """
       rule 'watch directory' do
-        watch __conf__ + 'foo/*.erb'
+        watch OpenHAB.conf_root + 'foo/*.erb'
         run { |event| logger.info("#{event.path.basename} - #{event.type}") }
       end
       """
     When I <action> a file in subdirectory 'foo' of conf named '<file>'
     Then It <should> log '<log>' within 5 seconds
     Examples:
-      | action | file      | should    | log                |
-      | create | qux.erb   | should    | qux.erb - created  | 
-      | delete | bar.erb   | should    | bar.erb - deleted  | 
-      | modify | baz.erb   | should    | baz.erb - modified | 
-      | create | qux       | should not| qux - created      | 
-      | delete | bar       | should not| qux - deleted      | 
-      | modify | baz       | should not| baz - modifie      | 
+      | action | file    | should     | log                |
+      | create | qux.erb | should     | qux.erb - created  |
+      | delete | bar.erb | should     | bar.erb - deleted  |
+      | modify | baz.erb | should     | baz.erb - modified |
+      | create | qux     | should not | qux - created      |
+      | delete | bar     | should not | qux - deleted      |
+      | modify | baz     | should not | baz - modifie      |
 
   Scenario Outline: Watch can limit event triggers
     Given a file in subdirectory 'foo' of conf named 'bar'
     And a deployed rule:
       """
       rule 'watch directory' do
-        watch __conf__ + 'foo', for: <event_type>
+        watch OpenHAB.conf_root + 'foo', for: <event_type>
         run { |event| logger.info("#{event.path.basename} - #{event.type}") }
       end
       """
     When I <action> a file in subdirectory 'foo' of conf named '<file>'
     Then It <should> log '<log>' within 5 seconds
     Examples:
-      | action | file      | event_type             | should    | log               |
-      | delete | bar       | :deleted               | should    | bar - deleted     | 
-      | delete | bar       | [:deleted, :modified]  | should    | bar - deleted     | 
-      | delete | bar       | :modified              | should not| bar - deleted     | 
-      | delete | bar       | [:modified,:created]   | should not| bar - deleted     | 
+      | action | file | event_type            | should     | log           |
+      | delete | bar  | :deleted              | should     | bar - deleted |
+      | delete | bar  | [:deleted, :modified] | should     | bar - deleted |
+      | delete | bar  | :modified             | should not | bar - deleted |
+      | delete | bar  | [:modified,:created]  | should not | bar - deleted |

--- a/lib/openhab/dsl/openhab.rb
+++ b/lib/openhab/dsl/openhab.rb
@@ -3,6 +3,15 @@
 require 'pathname'
 
 module OpenHAB
+  #
+  # Return the OpenHAB conf directory as a ruby pathname
+  #
+  # @return [Pathname] OpenHAB conf path
+  #
+  def self.conf_root
+    Pathname.new(ENV['OPENHAB_CONF'])
+  end
+
   module DSL
     #
     # Provides access to OpenHAB attributes
@@ -12,13 +21,9 @@ module OpenHAB
 
       module_function
 
-      #
-      # Return the OpenHAB conf directory as a ruby pathname
-      #
-      # @return [Pathname] OpenHAB conf path
-      #
+      # @deprecated Please use {OpenHAB.conf_root} instead
       def __conf__
-        Pathname.new(ENV['OPENHAB_CONF'])
+        OpenHAB.conf_root
       end
     end
   end


### PR DESCRIPTION
Resolve #528 

`__conf__` is still available. It calls `OpenHAB.conf_root` with the YARD tag `@deprecated`. It may/should be removed in a future breaking change.

