### PR TITLE
feat(timers[]): add #reschedule, rename #cancel_all to #cancel

### DIFF
--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -668,7 +668,7 @@ rule 'cancel all timers' do
   received_command Cancel_All_Timers, to: ON # Send a command to this item to cancel all timers
   run do
     gOutdoorLights.each do |item_as_timer_id|
-      timers[item_as_timer_id]&.cancel_all 
+      timers[item_as_timer_id]&.cancel 
     end
   end
 end
@@ -677,7 +677,7 @@ rule 'reschedule all timers' do
   received_command Reschedule_All_Timers, to: ON # Send a command to this item to restart all timers
   run do
     gOutdoorLights.each do |item_as_timer_id|
-      timers[item_as_timer_id]&.each(&:reschedule) # Note timers[] returns a Set of timers
+      timers[item_as_timer_id]&.reschedule
     end
   end
 end

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ end
 # timers[] is a pre-existing array that keeps track of reentrant timer ids
 rule 'cancel timer' do
   changed Light_Item, to: OFF
-  run { timers[Motion_Sensor]&.cancel_all }
+  run { timers[Motion_Sensor]&.cancel }
 end
 
 ```

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -258,7 +258,7 @@ Feature:  timer
       end
 
       rule 'Cancel timer' do
-        run { timers[:foo]&.cancel_all }
+        run { timers[:foo]&.cancel }
         on_start true
       end
       """
@@ -290,7 +290,7 @@ Feature:  timer
         on_start true
         run do
           logger.info("timers[:foo] is nil before cancel: #{timers[:foo].nil?}")
-          timers[:foo]&.cancel_all
+          timers[:foo]&.cancel
           logger.info("timers[:foo] is nil after cancel: #{timers[:foo].nil?}")
         end
       end
@@ -298,4 +298,21 @@ Feature:  timer
     When I deploy the rule
     Then It should log 'timers[:foo] is nil before cancel: false' within 5 seconds
     And It should log 'timers[:foo] is nil after cancel: true' within 5 seconds
+
+  Scenario: Managed timers can be rescheduled
+    Given code in a rules file:
+      """
+      after 1.hours, :id => :foo do
+        logger.info "Timer Fired"
+      end
+
+      rule 'Cancel timer' do
+        on_start
+        run do
+          timers[:foo]&.reschedule 1.second
+        end
+      end
+      """
+    When I deploy the rule
+    Then It should log 'Timer Fired' within 5 seconds
 

--- a/lib/openhab/dsl/timers/manager.rb
+++ b/lib/openhab/dsl/timers/manager.rb
@@ -95,10 +95,23 @@ module OpenHAB
       class TimerSet < Set
         #
         # A shorthand to cancel all the timer objects held within the set
-        # so that timers[timer_id].cancel_all is equivalent to timers[timer_id].each(&:cancel)
+        # so that timers[timer_id].cancel is equivalent to timers[timer_id].each(&:cancel)
         #
-        def cancel_all
+        def cancel
           each(&:cancel)
+        end
+        # @deprecated Please use {cancel} instead
+        alias cancel_all cancel
+
+        #
+        # A shorthand to reschedule all the timer objects held within the set
+        #
+        # @param [Duration] duration An optional duration to reschedule
+        #
+        # @return [TimerSet] Set of timers
+        #
+        def reschedule(duration = nil)
+          each { |timer| timer.reschedule duration }
         end
       end
     end


### PR DESCRIPTION
Most of the time, only one reentrant timer is created / manipulated, so adding a helper method to cancel and reschedule would be nice.

* Add timers[id].reschedule as an alias for timers[id].each(&:reschedule)
* Add timers[id].cancel as an alias for timers[id].each(&:cancel) - the previous timers[id].cancel_all is made an alias for cancel.
* Minor tweak to the timers doc
