### PR TITLE
test: add http readiness check

### DIFF
--- a/features/states.feature
+++ b/features/states.feature
@@ -38,20 +38,15 @@ Feature:  states
       """
       Switch1.update <state>
       sleep 0.5
-      if state? Switch1, Switch2
-        logger.info "All items have a valid state"
-      else
-        logger.info "Some states are nil"
-      end
+      logger.info "All items have a valid state: #{state? Switch1, Switch2}"
       """
     When I start deploying the rule
-    Then It <should> log "All items have a valid state" within 3 seconds
-    And It <should_not> log "Some states are nil" within 3 seconds
+    Then It should log "All items have a valid state: <result>" within 3 seconds
     Examples:
-      | state | should     | should_not |
-      | ON    | should     | should not |
-      | UNDEF | should not | should     |
-      | NULL  | should not | should     |
+      | state | result |
+      | ON    | true   |
+      | UNDEF | false  |
+      | NULL  | false  |
 
   Scenario Outline: Check item states before executing a rule
     Given code in a rules file:
@@ -61,16 +56,17 @@ Feature:  states
       rule 'state check' do
         on_start
         only_if { state? Switch1, Switch2 }
-        run { logger.info "All items have a valid state" }
+        run { logger.info "All items have a valid state: true" }
+        otherwise { logger.info "All items have a valid state: false" }
       end
       """
     When I deploy the rule
-    Then It <should> log "All items have a valid state" within 3 seconds
+    Then It should log "All items have a valid state: <result>" within 3 seconds
     Examples:
-      | state | should     |
-      | ON    | should     |
-      | UNDEF | should not |
-      | NULL  | should not |
+      | state | result |
+      | ON    | true   |
+      | UNDEF | false  |
+      | NULL  | false  |
 
   Scenario Outline: Check item states and their thing status
     Given feature 'openhab-binding-astro' installed

--- a/features/time_of_day.feature
+++ b/features/time_of_day.feature
@@ -1,60 +1,56 @@
 Feature:  time_of_day
-    Rule languages supports comparing using TimeOfDay
+  Rule languages supports comparing using TimeOfDay
 
-    Background:
-        Given Clean OpenHAB with latest Ruby Libraries
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
 
-    Scenario Outline: Parse strings into a TimeOfDay object
-        Given a rule template:
-            """
-            begin
-              logger.info("TimeOfDay is #{TimeOfDay.parse <template_time>}")
-            rescue ArgumentError => e
-              logger.error("Error parsing time #{e}")
-            end
-            """
-        When I deploy the rule
-        Then It should log "<log_line>" within 5 seconds
-        Examples:
-            | template_time | log_line              |
-            | '1'           | TimeOfDay is 01:00    |
-            | '02'          | TimeOfDay is 02:00    |
-            | '1pm'         | TimeOfDay is 13:00    |
-            | '12:30'       | TimeOfDay is 12:30    |
-            | '12 am'       | TimeOfDay is 00:00    |
-            | '7:00 AM'     | TimeOfDay is 07:00    |
-            | '7:00 pm'     | TimeOfDay is 19:00    |
-            | '7:30:20am'   | TimeOfDay is 07:30:20 |
-            | '12  am'      | Error parsing time    |
-            | '17:00pm'     | Error parsing time    |
-            | '17:00am'     | Error parsing time    |
-
-
-    Scenario Outline: TimeOfDay object can be compared against a string
-        Given a rule template:
-            """
-        if TimeOfDay.now < <template_time>
-          logger.info("Time of day compare succeded")
-        end
-            """
-        When I deploy the rule
-        Then It <should> log "Time of day compare succeded" within 5 seconds
-        Examples:
-            | template_time                                   | should     |
-            | '<%=(Time.now + (5*60)).strftime('%H:%M:%S')%>' | should     |
-            | '<%=(Time.now - (5*60)).strftime('%H:%M:%S')%>' | should not |
+  Scenario Outline: Parse strings into a TimeOfDay object
+    Given a rule template:
+      """
+      begin
+        logger.info("TimeOfDay is #{TimeOfDay.parse <template_time>}")
+      rescue ArgumentError => e
+        logger.error("Error parsing time #{e}")
+      end
+      """
+    When I deploy the rule
+    Then It should log "<log_line>" within 5 seconds
+    Examples:
+      | template_time | log_line              |
+      | '1'           | TimeOfDay is 01:00    |
+      | '02'          | TimeOfDay is 02:00    |
+      | '1pm'         | TimeOfDay is 13:00    |
+      | '12:30'       | TimeOfDay is 12:30    |
+      | '12 am'       | TimeOfDay is 00:00    |
+      | '7:00 AM'     | TimeOfDay is 07:00    |
+      | '7:00 pm'     | TimeOfDay is 19:00    |
+      | '7:30:20am'   | TimeOfDay is 07:30:20 |
+      | '12  am'      | Error parsing time    |
+      | '17:00pm'     | Error parsing time    |
+      | '17:00am'     | Error parsing time    |
 
 
-    Scenario Outline: TimeOfDay object between? method
-        Given a rule template:
-            """
-            if TimeOfDay.now.between? <from>..<to>
-                logger.info("TimeOfDay is in the range")
-            end
-            """
-        When I deploy the rule
-        Then It <should> log "TimeOfDay is in the range" within 2 seconds
-        Examples:
-            | from                                         | to                                           | should     |
-            | '<%=(Time.now - (5*60)).strftime('%H:%M')%>' | '<%=(Time.now + (5*60)).strftime('%H:%M')%>' | should     |
-            | '<%=(Time.now + (5*60)).strftime('%H:%M')%>' | '<%=(Time.now + (7*60)).strftime('%H:%M')%>' | should not |
+  Scenario Outline: TimeOfDay object can be compared against a string
+    Given a rule:
+      """
+      logger.info("Time of day compare result: #{TimeOfDay.noon < <time>}")
+      """
+    When I deploy the rule
+    Then It should log "Time of day compare result: <result>" within 5 seconds
+    Examples:
+      | time       | result |
+      | '12:05:00' | true   |
+      | '11:55:00' | false  |
+
+
+  Scenario Outline: TimeOfDay object between? method
+    Given a rule:
+      """
+      logger.info("TimeOfDay is in the range: #{TimeOfDay.noon.between? <from>..<to>}")
+      """
+    When I deploy the rule
+    Then It should log "TimeOfDay is in the range: <result>" within 2 seconds
+    Examples:
+      | from       | to         | result |
+      | '11:55:00' | '12:05:00' | true   |
+      | '12:05:00' | '12:10:00' | false  |


### PR DESCRIPTION
Fix #576

Working in my time zone, I sometimes trigger the tests near utc midnight. As a result, comparisons like
`TimeOfDay.now < (Time.now + 5*60).strftime('%H:%M:%S')` would return `false` when now >= `23:55:00`. This would cause the test to fail when running within this 5-minute window before midnight.

So I shifted the test to comparing TimeOfDay.noon against static time strings