### PR TITLE
feat(semantics): incorporate flat_map into Enumerable#points

### DIFF
--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -707,7 +707,7 @@ See [Persistence]({{ site.baseurl }}{% link usage/misc/persistence.md %})
 # get the lightbulbs (equipment) in the room (location) 
 room_lights = LivingRoom_Motion.location.equipments(Semantics::Lightbulb)
 # get the switches (points)
-light_switches = room_lights.flat_map(&:members).points(Semantics::Switch)
+light_switches = room_lights.points(Semantics::Switch)
 # turn them all on if they're not already on
 light_switches.ensure.on
 ```

--- a/docs/usage/misc/semantics.md
+++ b/docs/usage/misc/semantics.md
@@ -83,7 +83,6 @@ rule "turn off all lights in the room when switch double-tapped down" do
       .item
       .location
       .equipments(Semantics::Lightbulb)
-      .flat_map(&:members)
       .points(Semantics::Switch)
       .ensure.off
   end

--- a/features/semantics.feature
+++ b/features/semantics.feature
@@ -14,16 +14,17 @@ Feature: semantics
       | LivingRoom_Light1_Bulb | gLivingRoom, gMyGroup | Lightbulb            |
       | LivingRoom_Light2_Bulb | gLivingRoom           | Lightbulb, CustomTag |
     And items:
-      | type   | name                         | groups                 | tags                      |
-      | Switch | NoSemantic                   |                        |                           |
-      | Dimmer | Patio_Light_Brightness       | Patio_Light_Bulb       | Control,Level             |
-      | Color  | Patio_Light_Color            | Patio_Light_Bulb       | Control,Light             |
-      | Switch | Patio_Motion                 | gPatio                 | MotionDetector, CustomTag |
-      | Dimmer | LivingRoom_Light1_Brightness | LivingRoom_Light1_Bulb | Control,Level             |
-      | Color  | LivingRoom_Light1_Color      | LivingRoom_Light1_Bulb | Control,Light             |
-      | Dimmer | LivingRoom_Light2_Brightness | LivingRoom_Light2_Bulb | Control,Level             |
-      | Color  | LivingRoom_Light2_Color      | LivingRoom_Light2_Bulb | Control,Light             |
-      | Switch | LivingRoom_Motion            | gLivingRoom            | MotionDetector            |
+      | type   | name                         | groups                           | tags                      |
+      | Switch | NoSemantic                   |                                  |                           |
+      | Dimmer | Patio_Light_Brightness       | Patio_Light_Bulb                 | Control,Level             |
+      | Color  | Patio_Light_Color            | Patio_Light_Bulb                 | Control,Light             |
+      | Switch | Patio_Motion                 | gPatio                           | MotionDetector, CustomTag |
+      | Dimmer | LivingRoom_Light1_Brightness | LivingRoom_Light1_Bulb           | Control,Level             |
+      | Color  | LivingRoom_Light1_Color      | LivingRoom_Light1_Bulb           | Control,Light             |
+      | Switch | LivingRoom_Light1_Custom     | LivingRoom_Light1_Bulb, gMyGroup |                           |
+      | Dimmer | LivingRoom_Light2_Brightness | LivingRoom_Light2_Bulb           | Control,Level             |
+      | Color  | LivingRoom_Light2_Color      | LivingRoom_Light2_Bulb           | Control,Light             |
+      | Switch | LivingRoom_Motion            | gLivingRoom                      | MotionDetector            |
 
   Scenario Outline: Items have semantics methods
     Given code in a rules file
@@ -95,6 +96,9 @@ Feature: semantics
       | item              | method                                                                | result                     |
       | LivingRoom_Motion | location.not_member_of(gMyGroup).tagged("CustomTag").map(&:name).sort | ["LivingRoom_Light2_Bulb"] |
       | LivingRoom_Motion | location.equipments.tagged("CustomTag").map(&:name).sort              | ["LivingRoom_Light2_Bulb"] |
+    Examples: Enumerable#members
+      | item                   | method                                       | result                       |
+      | gLivingRoom.equipments | members.member_of(gMyGroup).map(&:name).sort | ["LivingRoom_Light1_Custom"] |
 
   Scenario Outline: Enumerable supports points
     Given code in a rules file
@@ -161,13 +165,13 @@ Feature: semantics
     When I deploy the rules file
     Then It should log '["Equipment1", "Equipment2"]' within 5 seconds
 
-  Scenario: Get sub Equipment
+  Scenario: Get sub-equipment (equipment that belong to another equipment)
     Given groups:
       | name         | groups           | tags      |
       | SubEquipment | Patio_Light_Bulb | Lightbulb |
     And code in a rules file:
       """
-      logger.info gPatio.equipments(Semantics::Lightbulb).equipments.map(&:name)
+      logger.info gPatio.equipments(Semantics::Lightbulb).members.equipments.map(&:name)
       """
     When I deploy the rules file
     Then It should log '["SubEquipment"]' within 5 seconds

--- a/lib/openhab/dsl/items/semantics.rb
+++ b/lib/openhab/dsl/items/semantics.rb
@@ -235,9 +235,6 @@ module Enumerable
   # !@visibility private
   def filter_with_members(&block)
     selected, others = partition(&block)
-    others.select { |e| e.respond_to?(:members) }
-          .flat_map(&:members)
-          .select(&block)
-          .concat(selected)
+    others.members.select(&block).concat(selected)
   end
 end

--- a/lib/openhab/dsl/items/semantics/enumerable.rb
+++ b/lib/openhab/dsl/items/semantics/enumerable.rb
@@ -32,6 +32,11 @@ module Enumerable
     each { |i| i.update(state) }
   end
 
+  # Returns the group members the elements
+  def members
+    select { |e| e.respond_to? :members }.flat_map(&:members)
+  end
+
   # @!method refresh
   #   Send the +REFRESH+ command to every item in the collection
 


### PR DESCRIPTION
This will remove the need to call flat_map before calling Enumerable#points

Before:
```
Item.location
.equipments
.flat_map(&:members)
.points
```

after:
```
Item.location
.equipments
.points
```

Also add Enumerable#members, which is an idea from @ccutrer
This helps when doing something like `gLocation.equipments.members.member_of(NonSemanticGroup)`