### PR TITLE
test: restart openhab on persistent http error

### DIFF
--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -4,12 +4,23 @@ require 'securerandom'
 require 'json'
 
 Given('Clean OpenHAB with latest Ruby Libraries') do
-  delete_rules
-  delete_shared_libraries
-  delete_items
-  delete_things
-  delete_conf_foo
-  truncate_log
+  attempt = 1
+  begin
+    delete_rules
+    delete_shared_libraries
+    delete_items
+    delete_things
+    delete_conf_foo
+    truncate_log
+  rescue PersistentHTTP::Error => e
+    raise if attempt > 2
+
+    attempt += 1
+    puts "Error encountered: #{e.message}. Restarting Openhab for attempt ##{attempt}"
+    stop_openhab
+    start_openhab
+    retry
+  end
 end
 
 Then(/^It should log "([^"]*)" within (\d+) seconds$/) do |string, seconds|

--- a/features/support/openhab_rest.rb
+++ b/features/support/openhab_rest.rb
@@ -20,7 +20,7 @@ class Rest
   basic_auth 'foo', 'foo'
 
   def self.rules
-    retry_on_failure { get('/rest/rules') }
+    get('/rest/rules')
   end
 
   def self.rule(rule:)
@@ -121,15 +121,5 @@ class Rest
     body = { itemName: item_name, channelUID: channel_uid }
     escaped_channel_uid = URI.encode_www_form_component(channel_uid)
     put("/rest/links/#{item_name}/#{escaped_channel_uid}", headers: json, body: body.to_json)
-  end
-
-  def self.retry_on_failure(retries = 5)
-    1.upto(retries) do |i|
-      return yield
-    rescue PersistentHTTP::Error
-      raise if i >= retries
-
-      sleep 1
-    end
   end
 end


### PR DESCRIPTION
Another attempt to fix #576 

It seems that retrying the Rest / http request 5 times is futile, so I've removed that code here and instead restart openhab and retry.