### PR TITLE
fix(semantics): revert enumerable#points and fix a few edge cases

### DIFF
--- a/docs/examples/how_do_i.md
+++ b/docs/examples/how_do_i.md
@@ -707,7 +707,7 @@ See [Persistence]({{ site.baseurl }}{% link usage/misc/persistence.md %})
 # get the lightbulbs (equipment) in the room (location) 
 room_lights = LivingRoom_Motion.location.equipments(Semantics::Lightbulb)
 # get the switches (points)
-light_switches = room_lights.points(Semantics::Switch)
+light_switches = room_lights.members.points(Semantics::Switch)
 # turn them all on if they're not already on
 light_switches.ensure.on
 ```

--- a/docs/usage/misc/semantics.md
+++ b/docs/usage/misc/semantics.md
@@ -10,25 +10,85 @@ grand_parent: Usage
 # Semantics
 
 OpenHAB supports a [semantic model](https://www.openhab.org/docs/tutorial/model.html)
-to help you define relationships between items. 
-
+to help you define relationships between items.
 
 ## Item helper methods
 
-Several [semantics helper methods](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Semantics)
+Several [semantics helper methods](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Items/Semantics)
 are defined on items in order to easily navigate this model in your scripts.
 This can be extremely useful to find related items in rules that are executed for any member of a group.
 
+| Method           | Description                                                                                                                                                                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `semantic?`      | Returns true if the item has any semantic tags                                                                                                                                                                                                        |
+| `location?`      | Returns true if the item is a location                                                                                                                                                                                                                |
+| `equipment?`     | Returns trus if the item is an equipment                                                                                                                                                                                                              |
+| `point?`         | Returns true if the item is a point                                                                                                                                                                                                                   |
+| `location`       | The location group item that this item belongs to, or nil if it has no location.                                                                                                                                                                      |
+| `equipment`      | The equipment item that this item belongs to, or nil if it doesn't belong to an equipment.                                                                                                                                                            |
+| `points`         | Returns the related Point items. If the item is a location or an equipment, returns all the Points within its members. Otherwise, returns its sibling Points. Accepts 1-2 optional arguments of point type and/or property type to filter the result. |
+| `semantic_type`  | Returns the item's semantic class                                                                                                                                                                                                                     |
+| `location_type`  | Returns the sub-class of `Location` related to this Item                                                                                                                                                                                              |
+| `equipment_type` | Returns the sub-class of `Equipment` related to this Item                                                                                                                                                                                             |
+| `point_type`     | Returns the sub-class of `Point` this Item is tagged with                                                                                                                                                                                             |
+| `property_type`  | Returns the sub-class of `Property` this Item is tagged with                                                                                                                                                                                          |
+
 ## Enumerable helper methods
 
-[Enumerable helper methods](https://www.rubydoc.info/gems/openhab-scripting/Enumerable) 
+[Enumerable helper methods](https://www.rubydoc.info/gems/openhab-scripting/Enumerable)
 are also provided to complement the semantic model. These methods can be chained together to find specific item(s)
 based on custom tags or group memberships that are outside the semantic model.
 
-The Enumerable helper methods apply to everything from group members and `all_members`, 
-Semantic [#location](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Semantics#location-instance_method) 
-and [#equipment](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Semantics#equipment-instance_method) 
-(which are just Groups), to any array of items, which includes the return value of the `#points` method.
+| Method          | Description                                                                                                                                                  |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sublocations`  | Selects elements that are a semantics Location (optionally of the given type)                                                                                |
+| `equipments`    | Selects elements that are a semantics equipment (optionally of the given type)                                                                               |
+| `points`        | Selects elements that are semantics points (optionally of a given type)                                                                                      |
+| `tagged`        | Selects elements that have at least one of the given tags                                                                                                    |
+| `not_tagged`    | Selects elements that do not have any of the given tags                                                                                                      |
+| `member_of`     | Selects elements that are a member of at least one of the given groups                                                                                       |
+| `not_member_of` | Selects elements that are not a member of any of the given groups                                                                                            |
+| `command`       | Send a command to every item in the collection                                                                                                               |
+| `update`        | Update the state of every item in the collection                                                                                                             |
+| `ensure`        | Apply [ensure state]({{ site.baseurl }}{% link usage/items/index.md %}#ensure_states) check on each member when `command` or `update` is chained afterwards. |
+| `members`       | Returns a new array that contains the group members of the elements. This is handy for finding Points in an array of Equipments or Locations.                |
+
+The Enumerable helper methods apply to:
+
+* Group item's `members` and `all_members`. This includes semantic
+  [#location](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Items/Semantics#location-instance_method)
+  and [#equipment](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Items/Semantics#equipment-instance_method)
+  because they are also group items. An exception is for Equipments that are an item (not a group)
+* Array of items, such as the return value of `#equipments`, `#sublocations`, `#points`, `#tagged`, `#not_tagged`,
+  `#member_of`, `#not_member_of`, `#members` methods, etc.
+
+## Semantic Classes
+
+Each [Semantic Tag](https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.semantics/model/SemanticTags.csv)
+has a corresponding class within the `org.openhab.core.semantics.model` class hierarchy. These `semantic classes` are available
+as constants in the `Semantics` module with the corresponding name. The following table illustrates the semantic constants:
+
+| Semantic Constant       | openHAB's Semantic Class                               |
+| ----------------------- | ------------------------------------------------------ |
+| `Semantics::LivingRoom` | `org.openhab.core.semantics.model.location.LivingRoom` |
+| `Semantics::Lightbulb`  | `org.openhab.core.semantics.model.equipment.Lightbulb` |
+| `Semantics::Control`    | `org.openhab.core.semantics.model.point.Control`       |
+| `Semantics::Switch`     | `org.openhab.core.semantics.model.point.Switch`        |
+| `Semantics::Power`      | `org.openhab.core.semantics.model.property.Power`      |
+| ...                     | ...                                                    |
+
+These constants can be used as arguments to the `#points`, `#sublocations` and `#equipments` methods to filter their results.
+They can also be compared against the return value of `semantic_type`, `location_type`, `equipment_type`,
+`point_type`, and `property_type`.
+
+```ruby
+# Return an array of sibling points with a "Switch" tag
+Light_Color.points(Semantics::Switch)
+
+# check semantic type
+LoungeRoom_Light.equipment_type == Semantics::Lightbulb
+Light_Color.property_type == Semantics::Light
+```
 
 ## Examples
 
@@ -36,16 +96,16 @@ and [#equipment](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Sem
 
 switches.items
 
-```
-Group gFullOn
+```java
+Group   gFullOn
 
-Group eGarageLights "Garage Lights" (lGarage) [ "Lightbulb" ]
-Dimmer GarageLights_Dimmer "Garage Lights" <light> (eGarageLights) [ "Switch" ]
-Number GarageLights_Scene "Scene" (eGarageLights, gFullOn)
+Group   eGarageLights        "Garage Lights"             (lGarage)                 [ "Lightbulb" ]
+Dimmer  GarageLights_Dimmer  "Garage Lights"    <light>  (eGarageLights)           [ "Switch" ]
+Number  GarageLights_Scene   "Scene"                     (eGarageLights, gFullOn)
 
-Group eMudLights "Mud Room Lights" (lMud) [ "Lightbulb" ]
-Dimmer MudLights_Dimmer "Garage Lights" <light> (eMudLights) [ "Switch" ]
-Number MudLights_Scene "Scene" (eMudLights, gFullOn)
+Group   eMudLights           "Mud Room Lights"           (lMud)                    [ "Lightbulb" ]
+Dimmer  MudLights_Dimmer     "Garage Lights"    <light>  (eMudLights)              [ "Switch" ]
+Number  MudLights_Scene      "Scene"                     (eMudLights, gFullOn)
 ```
 
 switches.rb
@@ -62,19 +122,20 @@ end
 
 ### Turn off all the lights in a room
 
-```
-Group gRoomOff
+```java
+Group   gRoomOff
 
-Group eGarageLights "Garage Lights" (lGarage) [ "Lightbulb" ]
-Dimmer GarageLights_Dimmer "Garage Lights" <light> (eGarageLights) [ "Switch" ]
-Number GarageLights_Scene "Scene" (eGarageLights, gRoomOff)
+Group   eGarageLights        "Garage Lights"             (lGarage)                  [ "Lightbulb" ]
+Dimmer  GarageLights_Dimmer  "Garage Lights"    <light>  (eGarageLights)            [ "Switch" ]
+Number  GarageLights_Scene   "Scene"                     (eGarageLights, gRoomOff)
 
-Group eMudLights "Mud Room Lights" (lGarage) [ "Lightbulb" ]
-Dimmer MudLights_Dimmer "Garage Lights" <light> (eMudLights) [ "Switch" ]
-Number MudLights_Scene "Scene" (eMudLights)
+Group   eMudLights           "Mud Room Lights"           (lGarage)                  [ "Lightbulb" ]
+Dimmer  MudLights_Dimmer     "Garage Lights"    <light>  (eMudLights)               [ "Switch" ]
+Number  MudLights_Scene      "Scene"                     (eMudLights)
 ```
 
 switches.rb
+
 ```ruby
 rule "turn off all lights in the room when switch double-tapped down" do
   changed gRoomOff.members, to: 2.3
@@ -83,6 +144,7 @@ rule "turn off all lights in the room when switch double-tapped down" do
       .item
       .location
       .equipments(Semantics::Lightbulb)
+      .members
       .points(Semantics::Switch)
       .ensure.off
   end
@@ -91,24 +153,24 @@ end
 
 ### Finding a related item that doesn't fit in the semantic model
 
-We can use custom tags to identify certain items that don't quite fit in the semantic model. 
+We can use custom tags to identify certain items that don't quite fit in the semantic model.
 The extensions to the Enumerable mentioned above can help in this scenario.
 
 In the following example, the TV `Equipment` has three `Points`. However, we are using custom tags
 `Application` and `Channel` to identify the corresponding points, since the semantic model
 doesn't have a specific property for them.
 
-Here, we use [Enumerable#tagged](https://www.rubydoc.info/gems/openhab-scripting/Enumerable#tagged-instance_method) 
+Here, we use [Enumerable#tagged](https://www.rubydoc.info/gems/openhab-scripting/Enumerable#tagged-instance_method)
 to find the point with the custom tag that we want.
 
-```
+```java
 Group   gTVPower
-Group   lLivingRoom                                            ["LivingRoom"]
+Group   lLivingRoom                                 [ "LivingRoom" ]
 
-Group   eLivingRoom_TV             (lLivingRoom)               ["Television"]
-Switch  LivingRoom_TV_Power        (eLivingRoom_TV, gTVPower)  ["Switch", "Power"]
-String  LivingRoom_TV_Application  (eLivingRoom_TV)            ["Control", "Application"]
-String  LivingRoom_TV_Channel      (eLivingRoom_TV)            ["Control", "Channel"]
+Group   eTV             "TV"       (lLivingRoom)    [ "Television" ]
+Switch  TV_Power        "Power"    (eTV, gTVPower)  [ "Switch", "Power" ]
+String  TV_Application  "App"      (eTV)            [ "Control", "Application" ]
+String  TV_Channel      "Channel"  (eTV)            [ "Control", "Channel" ]
 ```
 
 ```ruby

--- a/lib/openhab/dsl/items/group_item.rb
+++ b/lib/openhab/dsl/items/group_item.rb
@@ -44,6 +44,7 @@ module OpenHAB
 
         include Enumerable
         include ComparableItem
+        prepend Semantics # make Semantics#points take precedence over Enumerable#points for GroupItem
 
         remove_method :==
 

--- a/lib/openhab/dsl/items/semantics.rb
+++ b/lib/openhab/dsl/items/semantics.rb
@@ -4,168 +4,167 @@ require_relative 'semantics/enumerable'
 
 module OpenHAB
   module DSL
-    # Module for implementing semantics helper methods on [GenericItem]
-    #
-    # Wraps https://www.openhab.org/javadoc/latest/org/openhab/core/model/script/actions/semantics,
-    # as well as adding a few additional convenience methods.
-    # Also includes Classes for each semantic tag.
-    #
-    # Be warned that the Semantic model is stricter than can actually be
-    # described by tags and groups on an Item. It makes assumptions that any
-    # given item only belongs to one semantic type (Location, Equipment, Point).
-    #
-    # See https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.semantics/model/SemanticTags.csv
-    module Semantics
-      # @!visibility private
-      # import the actual semantics action
-      SemanticsAction = org.openhab.core.model.script.actions.Semantics
-      private_constant :SemanticsAction
+    module Items
+      # Module for implementing semantics helper methods on [GenericItem]
+      #
+      # Wraps https://www.openhab.org/javadoc/latest/org/openhab/core/model/script/actions/semantics,
+      # as well as adding a few additional convenience methods.
+      # Also includes Classes for each semantic tag.
+      #
+      # Be warned that the Semantic model is stricter than can actually be
+      # described by tags and groups on an Item. It makes assumptions that any
+      # given item only belongs to one semantic type (Location, Equipment, Point).
+      #
+      # See https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.semantics/model/SemanticTags.csv
+      module Semantics
+        # @!visibility private
+        # import the actual semantics action
+        SemanticsAction = org.openhab.core.model.script.actions.Semantics
+        private_constant :SemanticsAction
 
-      # import all the semantics constants
-      [org.openhab.core.semantics.model.point.Points,
-       org.openhab.core.semantics.model.property.Properties,
-       org.openhab.core.semantics.model.equipment.Equipments,
-       org.openhab.core.semantics.model.location.Locations].each do |parent_tag|
-        parent_tag.stream.for_each do |tag|
-          const_set(tag.simple_name.to_sym, tag.ruby_class)
+        # import all the semantics constants
+        [org.openhab.core.semantics.model.point.Points,
+         org.openhab.core.semantics.model.property.Properties,
+         org.openhab.core.semantics.model.equipment.Equipments,
+         org.openhab.core.semantics.model.location.Locations].each do |parent_tag|
+          parent_tag.stream.for_each do |tag|
+            const_set(tag.simple_name.to_sym, tag.ruby_class)
+          end
         end
-      end
 
-      # put ourself into the global namespace, replacing the action
-      ::Semantics = self # rubocop:disable Naming/ConstantName
+        # put ourself into the global namespace, replacing the action
+        ::Semantics = self # rubocop:disable Naming/ConstantName
 
-      # Checks if this Item is a Location
-      #
-      # This is implemented as checking if the item's semantic_type
-      # is a Location. I.e. an Item has a single semantic_type.
-      #
-      # @return [true, false]
-      def location?
-        SemanticsAction.location?(self)
-      end
+        # Checks if this Item is a Location
+        #
+        # This is implemented as checking if the item's semantic_type
+        # is a Location. I.e. an Item has a single semantic_type.
+        #
+        # @return [true, false]
+        def location?
+          SemanticsAction.location?(self)
+        end
 
-      # Checks if this Item is an Equipment
-      #
-      # This is implemented as checking if the item's semantic_type
-      # is an Equipment. I.e. an Item has a single semantic_type.
-      #
-      # @return [true, false]
-      def equipment?
-        SemanticsAction.equipment?(self)
-      end
+        # Checks if this Item is an Equipment
+        #
+        # This is implemented as checking if the item's semantic_type
+        # is an Equipment. I.e. an Item has a single semantic_type.
+        #
+        # @return [true, false]
+        def equipment?
+          SemanticsAction.equipment?(self)
+        end
 
-      # Checks if this Item is a Point
-      #
-      # This is implemented as checking if the item's semantic_type
-      # is a Point. I.e. an Item has a single semantic_type.
-      #
-      # @return [true, false]
-      def point?
-        SemanticsAction.point?(self)
-      end
+        # Checks if this Item is a Point
+        #
+        # This is implemented as checking if the item's semantic_type
+        # is a Point. I.e. an Item has a single semantic_type.
+        #
+        # @return [true, false]
+        def point?
+          SemanticsAction.point?(self)
+        end
 
-      # Checks if this Item has any semantic tags
-      # @return [true, false]
-      def semantic?
-        !!semantic_type
-      end
+        # Checks if this Item has any semantic tags
+        # @return [true, false]
+        def semantic?
+          !!semantic_type
+        end
 
-      # Gets the related Location Item of this Item.
-      #
-      # Returns +self+ if this Item is a Location. Otherwise, checks ancestor
-      # groups one level at a time, returning the first Location Item found.
-      #
-      # @return [GenericItem, nil]
-      def location
-        SemanticsAction.get_location(self)
-      end
+        # Gets the related Location Item of this Item.
+        #
+        # Returns +self+ if this Item is a Location. Otherwise, checks ancestor
+        # groups one level at a time, returning the first Location Item found.
+        #
+        # @return [GenericItem, nil]
+        def location
+          SemanticsAction.get_location(self)
+        end
 
-      # Returns the sub-class of [Location] related to this Item.
-      #
-      # In other words, the semantic_type of this Item's Location.
-      #
-      # @return [Class]
-      def location_type
-        SemanticsAction.get_location_type(self)&.ruby_class
-      end
+        # Returns the sub-class of [Location] related to this Item.
+        #
+        # In other words, the semantic_type of this Item's Location.
+        #
+        # @return [Class]
+        def location_type
+          SemanticsAction.get_location_type(self)&.ruby_class
+        end
 
-      # Gets the related Equipment Item of this Item.
-      #
-      # Returns +self+ if this Item is an Equipment. Otherwise, checks ancestor
-      # groups one level at a time, returning the first Equipment Item found.
-      #
-      # @return [GenericItem, nil]
-      def equipment
-        SemanticsAction.get_equipment(self)
-      end
+        # Gets the related Equipment Item of this Item.
+        #
+        # Returns +self+ if this Item is an Equipment. Otherwise, checks ancestor
+        # groups one level at a time, returning the first Equipment Item found.
+        #
+        # @return [GenericItem, nil]
+        def equipment
+          SemanticsAction.get_equipment(self)
+        end
 
-      # Returns the sub-class of [Equipment] related to this Item.
-      #
-      # In other words, the semantic_type of this Item's Equipment.
-      #
-      # @return [Class]
-      def equipment_type
-        SemanticsAction.get_equipment_type(self)&.ruby_class
-      end
+        # Returns the sub-class of [Equipment] related to this Item.
+        #
+        # In other words, the semantic_type of this Item's Equipment.
+        #
+        # @return [Class]
+        def equipment_type
+          SemanticsAction.get_equipment_type(self)&.ruby_class
+        end
 
-      # Returns the sub-class of [Point] this Item is tagged with.
-      #
-      # @return [Class]
-      def point_type
-        SemanticsAction.get_point_type(self)&.ruby_class
-      end
+        # Returns the sub-class of [Point] this Item is tagged with.
+        #
+        # @return [Class]
+        def point_type
+          SemanticsAction.get_point_type(self)&.ruby_class
+        end
 
-      # Returns the sub-class of [Property] this Item is tagged with.
-      # @return [Class]
-      def property_type
-        SemanticsAction.get_property_type(self)&.ruby_class
-      end
+        # Returns the sub-class of [Property] this Item is tagged with.
+        # @return [Class]
+        def property_type
+          SemanticsAction.get_property_type(self)&.ruby_class
+        end
 
-      # Returns the sub-class of [Tag] this Item is tagged with.
-      #
-      # It will only return the first applicable Tag, preferring
-      # a sub-class of [Location], [Equipment], or [Point] first,
-      # and if none of those are found, looks for a [Property].
-      # @return [Class]
-      def semantic_type
-        SemanticsAction.get_semantic_type(self)&.ruby_class
-      end
+        # Returns the sub-class of [Tag] this Item is tagged with.
+        #
+        # It will only return the first applicable Tag, preferring
+        # a sub-class of [Location], [Equipment], or [Point] first,
+        # and if none of those are found, looks for a [Property].
+        # @return [Class]
+        def semantic_type
+          SemanticsAction.get_semantic_type(self)&.ruby_class
+        end
 
-      # Return the related Point Items.
-      #
-      # Searches this Equipment Item for Points that are tagged appropriately.
-      #
-      # If called on a Point Item, it will automatically search for sibling Points
-      # (and remove itself if found).
-      #
-      # @example Get all points for a TV
-      #   eGreatTV.points
-      # @example Search an Equipment item for its switch
-      #   eGuestFan.points(Semantics::Switch) # => [GuestFan_Dimmer]
-      # @example Search a Thermostat item for its current temperature item
-      #   eFamilyThermostat.points(Semantics::Status, Semantics::Temperature)
-      #   # => [FamilyThermostat_AmbTemp]
-      # @example Search a Thermostat item for is setpoints
-      #   eFamilyThermostat.points(Semantics::Control, Semantics::Temperature)
-      #   # => [FamilyThermostat_HeatingSetpoint, FamilyThermostat_CoolingSetpoint]
-      # @example Given a A/V receiver's input item, search for its power item
-      #   FamilyReceiver_Input.points(Semantics::Switch) # => [FamilyReceiver_Switch]
-      #
-      # @param [Class] point_or_property_types
-      #   Pass 1 or 2 classes that are sub-classes of [Point] or [Property].
-      #   Note that when comparing against semantic tags, it does a sub-class check.
-      #   So if you search for [Control], you'll get items tagged with [Switch].
-      # @return [Array<GenericItem>]
-      def points(*point_or_property_types)
-        # automatically search the parent equipment (or location?!) for sibling points
-        unless equipment? || location?
+        # Return the related Point Items.
+        #
+        # Searches this Equipment Item for Points that are tagged appropriately.
+        #
+        # If called on a Point Item, it will automatically search for sibling Points
+        # (and remove itself if found).
+        #
+        # @example Get all points for a TV
+        #   eGreatTV.points
+        # @example Search an Equipment item for its switch
+        #   eGuestFan.points(Semantics::Switch) # => [GuestFan_Dimmer]
+        # @example Search a Thermostat item for its current temperature item
+        #   eFamilyThermostat.points(Semantics::Status, Semantics::Temperature)
+        #   # => [FamilyThermostat_AmbTemp]
+        # @example Search a Thermostat item for is setpoints
+        #   eFamilyThermostat.points(Semantics::Control, Semantics::Temperature)
+        #   # => [FamilyThermostat_HeatingSetpoint, FamilyThermostat_CoolingSetpoint]
+        # @example Given a A/V receiver's input item, search for its power item
+        #   FamilyReceiver_Input.points(Semantics::Switch) # => [FamilyReceiver_Switch]
+        #
+        # @param [Class] point_or_property_types
+        #   Pass 1 or 2 classes that are sub-classes of [Point] or [Property].
+        #   Note that when comparing against semantic tags, it does a sub-class check.
+        #   So if you search for [Control], you'll get items tagged with [Switch].
+        # @return [Array<GenericItem>]
+        def points(*point_or_property_types)
+          return members.points(*point_or_property_types) if equipment? || location?
+
+          # automatically search the parent equipment (or location?!) for sibling points
           result = (equipment || location)&.points(*point_or_property_types) || []
           # remove self. but avoid state comparisons
           result.delete_if { |item| item.eql?(self) }
-          return result
         end
-
-        members.points(*point_or_property_types)
       end
     end
   end
@@ -175,7 +174,9 @@ end
 module Enumerable
   # Returns a new array of items that are a semantics Location (optionally of the given type)
   def sublocations(type = nil)
-    raise ArgumentError, 'type must be a subclass of Location' if type && !(type < OpenHAB::DSL::Semantics::Location)
+    if type && !(type < OpenHAB::DSL::Items::Semantics::Location)
+      raise ArgumentError, 'type must be a subclass of Location'
+    end
 
     result = select(&:location?)
     result.select! { |i| i.location_type <= type } if type
@@ -188,7 +189,9 @@ module Enumerable
   # @example Get all TVs in a room
   #   lGreatRoom.equipments(Semantics::Screen)
   def equipments(type = nil)
-    raise ArgumentError, 'type must be a subclass of Equipment' if type && !(type < OpenHAB::DSL::Semantics::Equipment)
+    if type && !(type < OpenHAB::DSL::Items::Semantics::Equipment)
+      raise ArgumentError, 'type must be a subclass of Equipment'
+    end
 
     result = select(&:equipment?)
     result.select! { |i| i.equipment_type <= type } if type
@@ -205,36 +208,20 @@ module Enumerable
       raise ArgumentError, "wrong number of arguments (given #{point_or_property_types.length}, expected 0..2)"
     end
     unless point_or_property_types.all? do |tag|
-             tag < OpenHAB::DSL::Semantics::Point || tag < OpenHAB::DSL::Semantics::Property
+             tag < OpenHAB::DSL::Items::Semantics::Point || tag < OpenHAB::DSL::Items::Semantics::Property
            end
       raise ArgumentError, 'point_or_property_types must all be a subclass of Point or Property'
     end
-    if point_or_property_types.count { |tag| tag < OpenHAB::DSL::Semantics::Point } > 1 ||
-       point_or_property_types.count { |tag| tag < OpenHAB::DSL::Semantics::Property } > 1
+    if point_or_property_types.count { |tag| tag < OpenHAB::DSL::Items::Semantics::Point } > 1 ||
+       point_or_property_types.count { |tag| tag < OpenHAB::DSL::Items::Semantics::Property } > 1
       raise ArgumentError, 'point_or_property_types cannot both be a subclass of Point or Property'
     end
 
-    filter_with_members(&:point?)
-      .select do |point|
-      point_or_property_types.all? do |tag|
-        (tag < OpenHAB::DSL::Semantics::Point && point.point_type&.<=(tag)) ||
-          (tag < OpenHAB::DSL::Semantics::Property && point.property_type&.<=(tag))
+    select do |point|
+      point.point? && point_or_property_types.all? do |tag|
+        (tag < OpenHAB::DSL::Items::Semantics::Point && point.point_type <= tag) ||
+          (tag < OpenHAB::DSL::Items::Semantics::Property && point.property_type&.<=(tag))
       end
     end
-  end
-
-  #
-  # Select the elements where the given block returns true.
-  # If the block returns false but the element is a GroupItem with members,
-  # merge its members into the result and filter them using the same block
-  #
-  # @param [Block] &block A block that returns true for the elements and members to be included in the result
-  #
-  # @return [Array] The resulting array
-  #
-  # !@visibility private
-  def filter_with_members(&block)
-    selected, others = partition(&block)
-    others.members.select(&block).concat(selected)
   end
 end


### PR DESCRIPTION
* fix(semantics): groupitem.points failed to return its siblings because the code in Semantics#points never got called. This commit put the Semantics module ahead of Enumerable.
* fix(semantics): revert the members search for enumerable#points. There were some cases where descending into members is wrong.
  * Move Semantics module into OpenHAB::DSL::Items to be consistent with Metadata and Persistence modules
* test(semantics): add tests to detect edge cases
* docs(semantics): improve semantics docs