### PR TITLE
test: restart openhab when delete_rules failed

### DIFF
--- a/features/step_definitions/openhab.rb
+++ b/features/step_definitions/openhab.rb
@@ -12,7 +12,7 @@ Given('Clean OpenHAB with latest Ruby Libraries') do
     delete_things
     delete_conf_foo
     truncate_log
-  rescue PersistentHTTP::Error => e
+  rescue StandardError => e
     raise if attempt > 2
 
     attempt += 1

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -181,16 +181,16 @@ def delete_things
 end
 
 def delete_rules
+  FileUtils.rm Dir.glob(File.join(rules_dir, '*.rb'))
   deleted = false
   check_auth { Rest.rules }.each do |rule|
     uid = rule['uid']
     Rest.delete_rule(uid)
     deleted = true
   end
-  FileUtils.rm Dir.glob(File.join(rules_dir, '*.rb'))
   return unless deleted
 
-  wait_until(seconds: 30, msg: 'Rules not empty') { Rest.rules.length.zero? }
+  wait_until(seconds: 10, msg: 'Rules not empty') { Rest.rules.length.zero? }
 end
 
 def delete_shared_libraries


### PR DESCRIPTION
restart openhab when delete_rules failed. Encountered a condition where openhab had undeletable orphaned rules which lead to an exception raised by wait_until
