### PR TITLE
feat(logging): change logger level predicate method names

### DIFF
--- a/docs/usage/misc/logging.md
+++ b/docs/usage/misc/logging.md
@@ -37,8 +37,7 @@ The `logger` object has the following methods:
 
 * `info`, `warn`, `error`, `debug`, and `trace` log a message at the corresponding level. They can accept a block
   that returns a string. The block is executed if the log level is enabled.
-* `info_enabled?`, `warn_enabled?`, `error_enabled?`, `debug_enabled?`, and `trace_enabled?` return true if the log level is enabled.
-
+* `info?`, `warn?`, `error?`, `debug?`, and `trace?` return true if the log level is enabled.
 
 ### Example
 

--- a/features/logging.feature
+++ b/features/logging.feature
@@ -20,6 +20,24 @@ Feature:  logging
       | info  |
       | error |
 
+  # Is this test necessary? Enabling it will add more test time.
+  @wip
+  Scenario Outline: Logging supports predicate methods
+    Given code in a rules file
+      """
+      # Log at a level
+      logger.info "log <level>? #{logger.<level>?}"
+      """
+    When I deploy the rules file
+    Then It should log /log <level>\? (true|false)/ within 5 seconds
+    Examples:
+      | level |
+      | trace |
+      | debug |
+      | warn  |
+      | info  |
+      | error |
+
   Scenario: Logging accepts block
     Given code in a rules file
       """

--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -54,7 +54,9 @@ module OpenHAB
         define_method(level) do |msg = nil, &block|
           log(severity: level, msg: msg, &block)
         end
-        define_method("#{level}_enabled?") { @sl4fj_logger.send("is_#{level}_enabled") }
+        define_method("#{level}?") { @sl4fj_logger.send("is_#{level}_enabled") }
+        # @deprecated
+        alias_method "#{level}_enabled?", "#{level}?"
       end
 
       #
@@ -62,7 +64,7 @@ module OpenHAB
       # @param [String] preamble to put at start of log message
       # @param [Hash] kwargs key and values to log
       def state(preamble = 'State:', **kwargs)
-        return unless trace_enabled?
+        return unless trace?
 
         states = kwargs.transform_keys(&:to_s)
                        .transform_keys(&:capitalize)
@@ -82,7 +84,7 @@ module OpenHAB
       # @return [Exception] the exception, potentially with a cleaned backtrace.
       #
       def clean_backtrace(error)
-        return error if debug_enabled?
+        return error if debug?
 
         if error.respond_to? :backtrace_locations
           backtrace = error.backtrace_locations.map(&:to_s).grep_v(INTERNAL_CALL_REGEX)
@@ -122,7 +124,7 @@ module OpenHAB
         raise ArgumentError, "Unknown Severity #{severity}" unless LEVELS.include? severity
 
         # Dynamically check enablement of underlying logger, this expands to "is_<level>_enabled"
-        return unless send("#{severity}_enabled?")
+        return unless send("#{severity}?")
 
         # Process block if no message provided
         msg = yield if msg.nil? && block_given?


### PR DESCRIPTION
Resolve #569 

Change `logger#level_enabled?` to `logger#level?`
Alias deprecated level_enabled? for backwards compatibility