### PR TITLE
fix: comparing non null vs null comparable-item objects raised an exception

### DIFF
--- a/features/items.feature
+++ b/features/items.feature
@@ -365,23 +365,30 @@ Feature:  items
     And It should log "DimmerTest in value? false" within 5 seconds
     And It should log "SwitchTest in value? false" within 5 seconds
 
-  Scenario: Direct comparison of Items
-    Given a rule:
+  Scenario Outline: Direct comparison of Items
+    Given items:
+      | type   | name               | state |
+      | String | NonNullStringItem1 | hi    |
+      | String | NullStringItem1    | NULL  |
+    And a rule:
       """
-      logger.info("State comparison: #{SwitchTwo == SwitchTest}")
-      logger.info("Different Item objects comparison1: #{SwitchTwo.item == SwitchTest.item}")
-      logger.info("Different Item objects comparison2: #{SwitchTwo.item == SwitchTest}")
-      logger.info("Same Item object comparison 1: #{SwitchTwo.item == items['SwitchTwo'].item}")
-      logger.info("Same Item object comparison 2: #{SwitchTwo == items['SwitchTwo'].item}")
-      logger.info("Same Item object comparison 3: #{SwitchTwo.item == items['SwitchTwo']}")
+      logger.info("<left> == <right>: #{<left> == <right>}")
       """
     When I deploy the rule
-    Then It should log "State comparison: true" within 5 seconds
-    And It should log "Different Item objects comparison1: false" within 5 seconds
-    And It should log "Different Item objects comparison2: false" within 5 seconds
-    And It should log "Same Item object comparison 1: true" within 5 seconds
-    And It should log "Same Item object comparison 2: true" within 5 seconds
-    And It should log "Same Item object comparison 3: true" within 5 seconds
+    Then It should log "<left> == <right>: <result>" within 5 seconds
+    Examples: State comparisons
+      | left      | right      | result |
+      | SwitchTwo | SwitchTest | true   |
+    Examples: Different item objects comparisons
+      | left               | right                | result |
+      | SwitchTwo.item     | SwitchTest.item      | false  |
+      | SwitchTwo.item     | SwitchTest           | false  |
+      | NonNullStringItem1 | NullStringItem1.item | false  |
+    Examples: Same item object comparisons
+      | left           | right                   | result |
+      | SwitchTwo.item | items['SwitchTwo'].item | true   |
+      | SwitchTwo      | items['SwitchTwo'].item | true   |
+      | SwitchTwo.item | items['SwitchTwo']      | true   |
 
   Scenario: GroupItem grep can use Item.item
     Given group "Switches"

--- a/lib/openhab/dsl/items/comparable_item.rb
+++ b/lib/openhab/dsl/items/comparable_item.rb
@@ -9,8 +9,11 @@ module OpenHAB
         #
         # Comparison
         #
-        # @param [GenericItem, Types::Type, Object] other object to
+        # @param [GenericItem, Types::Type, Object, GenericItemObject] other object to
         #   compare to
+        #
+        #   When comparing GenericItemObject on either side, perform object comparison
+        #   return 0 if the object is equal, or nil otherwise.
         #
         #   If this item is +NULL+ or +UNDEF+, and +other+ is nil, they are
         #   considered equal
@@ -28,20 +31,29 @@ module OpenHAB
         #
         def <=>(other)
           logger.trace("(#{self.class}) #{self} <=> #{other} (#{other.class})")
-          # if we're NULL or UNDEF, implement special logic
-          unless state?
-            # if comparing to nil, consider ourselves equal
-            return 0 if other.nil?
-            # if the other object is an Item, only consider equal if we're
-            # in the same _kind_ of UnDefType state
-            return raw_state == other.raw_state if other.is_a?(GenericItem) && !other.state?
 
-            # otherwise, it's a non-nil thing comparing to nil, which is undefined
-            return nil
+          if is_a?(OpenHAB::DSL::GenericItemObject) || other.is_a?(OpenHAB::DSL::GenericItemObject)
+            return eql?(other) ? 0 : nil
           end
+
+          # if we're NULL or UNDEF, implement special logic
+          return nil_comparison unless state?
 
           # delegate to how the state compares to the other object
           state <=> other
+        end
+
+        # Special logic for NULL/UNDEF state comparison
+        # @!visibility private
+        def nil_comparison
+          # if comparing to nil, consider ourselves equal
+          return 0 if other.nil?
+          # if the other object is an Item, only consider equal if we're
+          # in the same _kind_ of UnDefType state
+          return raw_state == other.raw_state if other.is_a?(GenericItem) && !other.state?
+
+          # otherwise, it's a non-nil thing comparing to nil, which is undefined
+          nil
         end
       end
     end


### PR DESCRIPTION
Related to #550

It seems that we need to extend the item equality comparison into `<=>`
I came across an error when performing an item object comparison which involved <=> instead of ==.
I think it applies to anything involving comparable types, such as string, number, etc. Our current tests only involved Switch items hence why we didn't catch it.