### PR TITLE
feat(semantics): rename sublocations to locations

### DIFF
--- a/docs/usage/misc/semantics.md
+++ b/docs/usage/misc/semantics.md
@@ -41,7 +41,7 @@ based on custom tags or group memberships that are outside the semantic model.
 
 | Method          | Description                                                                                                                                                  |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sublocations`  | Selects elements that are a semantics Location (optionally of the given type)                                                                                |
+| `locations`     | Selects elements that are a semantics Location (optionally of the given type)                                                                                |
 | `equipments`    | Selects elements that are a semantics equipment (optionally of the given type)                                                                               |
 | `points`        | Selects elements that are semantics points (optionally of a given type)                                                                                      |
 | `tagged`        | Selects elements that have at least one of the given tags                                                                                                    |
@@ -59,8 +59,9 @@ The Enumerable helper methods apply to:
   [#location](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Items/Semantics#location-instance_method)
   and [#equipment](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Items/Semantics#equipment-instance_method)
   because they are also group items. An exception is for Equipments that are an item (not a group)
-* Array of items, such as the return value of `#equipments`, `#sublocations`, `#points`, `#tagged`, `#not_tagged`,
+* Array of items, such as the return value of `#equipments`, `#locations`, `#points`, `#tagged`, `#not_tagged`,
   `#member_of`, `#not_member_of`, `#members` methods, etc.
+* `items[]` hash which contains all items in the system.
 
 ## Semantic Classes
 
@@ -77,7 +78,7 @@ as constants in the `Semantics` module with the corresponding name. The followin
 | `Semantics::Power`      | `org.openhab.core.semantics.model.property.Power`      |
 | ...                     | ...                                                    |
 
-These constants can be used as arguments to the `#points`, `#sublocations` and `#equipments` methods to filter their results.
+These constants can be used as arguments to the `#points`, `#locations` and `#equipments` methods to filter their results.
 They can also be compared against the return value of `semantic_type`, `location_type`, `equipment_type`,
 `point_type`, and `property_type`.
 
@@ -181,4 +182,29 @@ rule 'Switch TV to Netflix on startup' do
     application << 'netflix'
   end
 end
+```
+
+### Find all semantic entities regardless of hierarchy
+
+```ruby
+# All locations
+items.locations
+
+# All rooms
+items.locations(Semantics::Room)
+
+# All equipments
+items.equipments
+
+# All lightbulbs
+items.equipments(Semantics::Lightbulb)
+
+# All blinds
+items.equipments(Semantics::Blinds)
+
+# Turn off all "Power control"
+items.points(Semantics::Control, Semantics::Power).off
+
+# All items tagged "SmartLightControl"
+items.tagged("SmartLightControl")
 ```

--- a/features/semantics.feature
+++ b/features/semantics.feature
@@ -108,18 +108,18 @@ Feature: semantics
     When I deploy the rules file
     Then It should log 'Item <item>.<method>: <result>' within 5 seconds
     Examples: Enumerable methods
-      | item        | method                                               | result                                               |
-      | gPatio      | equipments.map(&:name).sort                          | ["Patio_Light_Bulb", "Patio_Motion"]                 |
-      | gIndoor     | sublocations.map(&:name).sort                        | ["gLivingRoom"]                                      |
-      | gIndoor     | sublocations(Semantics::Room).map(&:name).sort       | ["gLivingRoom"]                                      |
-      | gIndoor     | sublocations(Semantics::LivingRoom).map(&:name).sort | ["gLivingRoom"]                                      |
-      | gIndoor     | sublocations(Semantics::FamilyRoom).map(&:name).sort | []                                                   |
-      | gIndoor     | sublocations(Semantics::Light).map(&:name).sort      | Exception caught:                                    |
-      | items       | tagged("CustomTag").map(&:name).sort                 | ["LivingRoom_Light2_Bulb", "Patio_Motion"]           |
-      | gLivingRoom | tagged("Lightbulb").map(&:name).sort                 | ["LivingRoom_Light1_Bulb", "LivingRoom_Light2_Bulb"] |
-      | gLivingRoom | not_tagged("Lightbulb").map(&:name).sort             | ["LivingRoom_Motion"]                                |
-      | gLivingRoom | members.member_of(gMyGroup).map(&:name).sort         | ["LivingRoom_Light1_Bulb"]                           |
-      | gLivingRoom | members.not_member_of(gMyGroup).map(&:name).sort     | ["LivingRoom_Light2_Bulb", "LivingRoom_Motion"]      |
+      | item        | method                                            | result                                               |
+      | gPatio      | equipments.map(&:name).sort                       | ["Patio_Light_Bulb", "Patio_Motion"]                 |
+      | gIndoor     | locations.map(&:name).sort                        | ["gLivingRoom"]                                      |
+      | gIndoor     | locations(Semantics::Room).map(&:name).sort       | ["gLivingRoom"]                                      |
+      | gIndoor     | locations(Semantics::LivingRoom).map(&:name).sort | ["gLivingRoom"]                                      |
+      | gIndoor     | locations(Semantics::FamilyRoom).map(&:name).sort | []                                                   |
+      | gIndoor     | locations(Semantics::Light).map(&:name).sort      | Exception caught:                                    |
+      | items       | tagged("CustomTag").map(&:name).sort              | ["LivingRoom_Light2_Bulb", "Patio_Motion"]           |
+      | gLivingRoom | tagged("Lightbulb").map(&:name).sort              | ["LivingRoom_Light1_Bulb", "LivingRoom_Light2_Bulb"] |
+      | gLivingRoom | not_tagged("Lightbulb").map(&:name).sort          | ["LivingRoom_Motion"]                                |
+      | gLivingRoom | members.member_of(gMyGroup).map(&:name).sort      | ["LivingRoom_Light1_Bulb"]                           |
+      | gLivingRoom | members.not_member_of(gMyGroup).map(&:name).sort  | ["LivingRoom_Light2_Bulb", "LivingRoom_Motion"]      |
     Examples: Chaining methods
       | item              | method                                                                | result                     |
       | LivingRoom_Motion | location.not_member_of(gMyGroup).tagged("CustomTag").map(&:name).sort | ["LivingRoom_Light2_Bulb"] |

--- a/lib/openhab/dsl/items/semantics.rb
+++ b/lib/openhab/dsl/items/semantics.rb
@@ -173,7 +173,7 @@ end
 # Additions to Enumerable to allow easily filtering groups of items based on the semantic model
 module Enumerable
   # Returns a new array of items that are a semantics Location (optionally of the given type)
-  def sublocations(type = nil)
+  def locations(type = nil)
     if type && !(type < OpenHAB::DSL::Items::Semantics::Location)
       raise ArgumentError, 'type must be a subclass of Location'
     end
@@ -183,6 +183,8 @@ module Enumerable
 
     result
   end
+  # @deprecated Please use {#locations}
+  alias sublocations locations
 
   # Returns a new array of items that are a semantics equipment (optionally of the given type)
   #


### PR DESCRIPTION
For consistency's sake, rename `sublocations` to `locations`. The latter sounds more natural when being used on anything other than a location. e.g. `items.locations` vs `items.sublocations`

* Mark sublocations deprecated, but alias it to locations for compatibility
* Add more semantic examples