### PR TITLE
Optimize ci by reusing runners

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,6 @@
 name: Openhab-JRuby-Scripting
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -11,30 +11,29 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
-
- rubocop:
-   runs-on: ubuntu-latest
-   if: "!contains(github.event.head_commit.message, 'ci skip')"
-   steps:
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
+  rubocop:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-     - name: Rubocop 
-       run: bundle exec rubocop
+      - name: Rubocop
+        run: bundle exec rubocop
 
- commit-lint:
+  commit-lint:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
@@ -43,151 +42,153 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
 
- cucumber-lint:
-   runs-on: ubuntu-latest
-   if: "!contains(github.event.head_commit.message, 'ci skip')"
-   steps:
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
+  cucumber-lint:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-     - name: Cucumber Lint 
-       run: bundle exec cuke_linter -p features/
- 
- yard-coverage:
-   runs-on: ubuntu-latest
-   if: "!contains(github.event.head_commit.message, 'ci skip')"
-   steps:
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-     - name: Yard Coverage
-       run: |
-            bundle exec yard stats --list-undoc --private
-            bundle exec yard stats --private | grep "100.00% documented"
+      - name: Cucumber Lint
+        run: bundle exec cuke_linter -p features/
 
- openhab-matrix:
-   runs-on: ubuntu-latest
-   if: "!contains(github.event.head_commit.message, 'ci skip')"
-   outputs:
+  yard-coverage:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Yard Coverage
+        run: |
+          bundle exec yard stats --list-undoc --private
+          bundle exec yard stats --private | grep "100.00% documented"
+
+  openhab-matrix:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-   steps: 
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-     - id: set-matrix
-       run: |
-         JSON=$(bundle exec rake github:oh_versions)
-         echo $JSON
-         echo "::set-output name=matrix::$( echo "$JSON" )"
+      - id: set-matrix
+        run: |
+          JSON=$(bundle exec rake github:oh_versions)
+          echo $JSON
+          echo "::set-output name=matrix::$( echo "$JSON" )"
 
-
- openhab-setup:
-   needs: [openhab-matrix]
-   runs-on: ubuntu-latest
-   if: "!contains(github.event.head_commit.message, 'ci skip')"
-   strategy:
-    matrix:  ${{fromJson(needs.openhab-matrix.outputs.matrix)}}
-   steps:
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - uses: actions/setup-java@v1
-       with:
-         java-version: '11.0.8' 
-         java-package: jre
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Cache Gems 
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
+  openhab-setup:
+    needs: [openhab-matrix]
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    strategy:
+      matrix: ${{fromJson(needs.openhab-matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "11.0.8"
+          java-package: jre
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Cache Gems
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-     - name: Cache OpenHAB setup
-       id: cache
-       uses: actions/cache@v2
-       with: 
-        path: tmp/
-        key: OpenHAB-setup-${{ hashFiles('.bundlehash', 'Rakefile', 'rakelib/openhab.rake') }}-${{ matrix.openhab_version }}
-     - name: Setup OpenHAB
-       if: steps.cache.outputs.cache-hit != 'true'
-       env:
-          OPENHAB_VERSION: ${{ matrix.openhab_version }} 
-       run: bundle exec rake openhab:setup
- 
- cucumber-matrix:
-   runs-on: ubuntu-latest
-   if: "!contains(github.event.head_commit.message, 'ci skip')"
-   outputs:
+      - name: Cache OpenHAB setup
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: tmp/
+          key: OpenHAB-setup-${{ hashFiles('.bundlehash', 'Rakefile', 'rakelib/openhab.rake') }}-${{ matrix.openhab_version }}
+      - name: Setup OpenHAB
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          OPENHAB_VERSION: ${{ matrix.openhab_version }}
+        run: bundle exec rake openhab:setup
+
+  cucumber-matrix:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-   steps: 
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-     - id: set-matrix
-       run: |
-         JSON=$(bundle exec rake github:matrix)
-         echo $JSON
-         echo "::set-output name=matrix::$( echo "$JSON" )"
+      - name: Remove env.rb file
+        run: |
+          rm features/support/env.rb
+      - id: set-matrix
+        run: |
+          JSON=$(bundle exec rake github:matrix[20])
+          echo $JSON
+          echo "::set-output name=matrix::$( echo "$JSON" )"
 
- cucumber:
+  cucumber:
     needs: [cucumber-matrix, openhab-setup]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
-      matrix:  ${{fromJson(needs.cucumber-matrix.outputs.matrix)}}
+      matrix: ${{fromJson(needs.cucumber-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-ruby@v1
@@ -195,13 +196,13 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
       - uses: actions/setup-java@v1
         with:
-          java-version: '11.0.8' 
+          java-version: "11.0.8"
           java-package: jre
       - name: Install bundler
         run: gem install bundler:2.2.7 -N
-      - name: Restore Gems 
+      - name: Restore Gems
         uses: actions/cache@v2
-        with: 
+        with:
           path: vendor/bundle
           key: gems-${{ hashFiles('**/Gemfile.lock') }}
       - name: Install gems
@@ -210,11 +211,11 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Restore OpenHAB setup
         uses: actions/cache@v2
-        with: 
+        with:
           path: tmp/
           key: OpenHAB-setup-${{ hashFiles('.bundlehash', 'Rakefile', 'rakelib/openhab.rake') }}-${{ matrix.openhab_version }}
       - name: Cucumber
-        run: bundle exec rake features[${{ matrix.file }}]
+        run: bundle exec rake "features[${{ matrix.features }}]"
       - name: Generate OpenHAB Dump
         run: bundle exec rake openhab:dump
         if: failure()
@@ -222,101 +223,99 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: OpenHAB-logs-${{ github.workflow }}-${{ github.run_number }}-${{ matrix.feature }}
+          name: OpenHAB-logs-${{ github.workflow }}-${{ github.run_number }}-${{ matrix.features }}
           path: tmp/
           retention-days: 2
 
- pickles-docs:
-  if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'ci skip')
-  runs-on: windows-latest
-  steps:
-    - uses: actions/checkout@v2
-    - name: Install pickles
-      run: choco install pickles
-    - name: Generate Pickles docs
-      shell: cmd
-      run:  |
+  pickles-docs:
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'ci skip')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install pickles
+        run: choco install pickles
+      - name: Generate Pickles docs
+        shell: cmd
+        run: |
           call refreshenv
           pickles -f features -o pickles --df html || VER>NUL
-    - uses: actions/upload-artifact@v2
-      with:
-        name: pickles-docs
-        path: pickles/
-        if-no-files-found: error
-        retention-days: 1
-  
- docs:
-   needs: [cucumber, pickles-docs]
-   if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'ci skip')
-   runs-on: ubuntu-latest
-   steps:
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-         ruby-version: ${{ env.RUBY_VERSION }}
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-     - name: Build yard docs
-       run: |
-          bundle exec rake docs:yard
-     - name: Download pickles docs
-       uses: actions/download-artifact@v2
-       with:
-         name: pickles-docs
-         path: docs/pickles
-     - name: Publish docs
-       uses: JamesIves/github-pages-deploy-action@3.7.1
-       with:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         BRANCH: gh-pages 
-         FOLDER: docs 
-         CLEAN: true 
-         SINGLE_COMMIT: true 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pickles-docs
+          path: pickles/
+          if-no-files-found: error
+          retention-days: 1
 
- 
- release:
-   needs: cucumber 
-   if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'ci skip')
-   runs-on: ubuntu-latest
-   steps:
-     - uses: actions/checkout@v2
-     - uses: actions/setup-ruby@v1
-       with:
-        ruby-version: ${{ env.RUBY_VERSION }}
-     - uses: actions/setup-node@v2
-       with:
-        node-version: '15'
-     - name: Install bundler
-       run: gem install bundler:2.2.7 -N
-     - name: Gem Cache
-       uses: actions/cache@v2
-       with: 
-        path: vendor/bundle
-        key: gems-${{ hashFiles('**/Gemfile.lock') }}
-     - name: Install gems
-       run: |
+  docs:
+    needs: [cucumber, pickles-docs]
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'ci skip')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-     - name: Install Semantic Release
-       run: |
-         npm install semantic-release@^17.0.0
-         npm install @semantic-release/changelog@^5.0.0 -D
-         npm install @semantic-release/git@^9.0.0 -D
-         npm install semantic-release-rubygem@^1.0.0 -D
-         npm install conventional-changelog-conventionalcommits@^4.0.0 -D
-         npm install @semantic-release/changelog@^5.0.0 -D
-     - name: Release
-       run: |
+      - name: Build yard docs
+        run: |
+          bundle exec rake docs:yard
+      - name: Download pickles docs
+        uses: actions/download-artifact@v2
+        with:
+          name: pickles-docs
+          path: docs/pickles
+      - name: Publish docs
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs
+          CLEAN: true
+          SINGLE_COMMIT: true
+
+  release:
+    needs: cucumber
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'ci skip')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "15"
+      - name: Install bundler
+        run: gem install bundler:2.2.7 -N
+      - name: Gem Cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Install Semantic Release
+        run: |
+          npm install semantic-release@^17.0.0
+          npm install @semantic-release/changelog@^5.0.0 -D
+          npm install @semantic-release/git@^9.0.0 -D
+          npm install semantic-release-rubygem@^1.0.0 -D
+          npm install conventional-changelog-conventionalcommits@^4.0.0 -D
+          npm install @semantic-release/changelog@^5.0.0 -D
+      - name: Release
+        run: |
           npx semantic-release
-       env:
-        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
-     
+        env:
+          GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: OpenHAB-logs-${{ github.workflow }}-${{ github.run_number }}-${{ matrix.features }}
+          name: OpenHAB-logs-${{ github.workflow }}-${{ github.run_number }}-${{ matrix.index }}
           path: tmp/
           retention-days: 2
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,20 +16,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Gem Cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Rubocop
         run: bundle exec rubocop
 
@@ -47,20 +36,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Gem Cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Cucumber Lint
         run: bundle exec cuke_linter -p features/
 
@@ -69,20 +47,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Gem Cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Yard Coverage
         run: |
           bundle exec yard stats --list-undoc --private
@@ -95,20 +62,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Gem Cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - id: set-matrix
         run: |
           JSON=$(bundle exec rake github:oh_versions)
@@ -123,24 +79,9 @@ jobs:
       matrix: ${{fromJson(needs.openhab-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - uses: actions/setup-java@v1
-        with:
-          java-version: "11.0.8"
-          java-package: jre
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Cache Gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Cache OpenHAB setup
         id: cache
         uses: actions/cache@v2
@@ -160,20 +101,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Gem Cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Remove env.rb file
         run: |
           rm features/support/env.rb
@@ -191,24 +121,13 @@ jobs:
       matrix: ${{fromJson(needs.cucumber-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
       - uses: actions/setup-java@v1
         with:
-          java-version: "11.0.8"
+          java-version: "11"
           java-package: jre
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Restore Gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: Restore OpenHAB setup
         uses: actions/cache@v2
         with:
@@ -252,20 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install bundler
-        run: gem install bundler:2.2.7 -N
-      - name: Gem Cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-${{ hashFiles('**/Gemfile.lock') }}
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Build yard docs
         run: |
           bundle exec rake docs:yard
@@ -289,6 +197,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # We need to use the setup-ruby's non cached bundler action here
+      # otherwise the gem build will fail because it is not a development instance
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/features/ensure_states.feature
+++ b/features/ensure_states.feature
@@ -20,7 +20,7 @@ Feature:  ensure_states
         rule "command received" do
           <trigger_type> DimmerOne
           run do |event|
-            logger.trace("DimmerOne <trigger_type>")
+            logger.info("DimmerOne <trigger_type>")
           end
         end
         DimmerOne.ensure.<command>
@@ -55,11 +55,11 @@ Feature:  ensure_states
         rule "command received" do
           <trigger_type> DimmerOne
           run do |event|
-            logger.trace("DimmerOne <trigger_type>")
+            logger.info("DimmerOne <trigger_type>")
           end
         end
         DimmerOne.ensure.<command>
-        logger.trace("Command sent")
+        logger.info("Command sent")
       """
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
@@ -91,7 +91,7 @@ Feature:  ensure_states
         rule "command received" do
           received_command DimmerOne
           run do |event|
-            logger.trace("DimmerOne received command")
+            logger.info("DimmerOne received command")
           end
         end
         Dimmers.ensure.<command>
@@ -119,11 +119,11 @@ Feature:  ensure_states
         rule "command received" do
           received_command DimmerOne
           run do |event|
-            logger.trace("DimmerOne received command")
+            logger.info("DimmerOne received command")
           end
         end
         Dimmers.ensure.<command>
-        logger.trace("Command sent")
+        logger.info("Command sent")
       """
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
@@ -146,7 +146,7 @@ Feature:  ensure_states
         rule "command received" do
           received_command DimmerOne
           run do |event|
-            logger.trace("DimmerOne received command")
+            logger.info("DimmerOne received command")
           end
         end
         Dimmers.members.ensure.<command>
@@ -170,13 +170,13 @@ Feature:  ensure_states
         rule "command received" do
           <trigger_type> DimmerOne
           run do |event|
-            logger.trace("DimmerOne <trigger_type>")
+            logger.info("DimmerOne <trigger_type>")
           end
         end
         ensure_states do
           DimmerOne.<command>
         end
-        logger.trace("Command sent")
+        logger.info("Command sent")
       """
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
@@ -196,11 +196,11 @@ Feature:  ensure_states
         rule "command received" do
           <trigger_type> Switch1
           run do |event|
-            logger.trace("Switch1 <trigger_type>")
+            logger.info("Switch1 <trigger_type>")
           end
         end
         Switch1.ensure.<command>
-        logger.trace("Command sent")
+        logger.info("Command sent")
       """
     When I deploy the rules file
     Then It should log "Command sent" within 5 seconds
@@ -222,11 +222,11 @@ Feature:  ensure_states
         rule "command received" do
           received_command Switch1
           run do |event|
-            logger.trace("Switch1 received command")
+            logger.info("Switch1 received command")
           end
         end
         Switch1.ensure.update ON
-        logger.trace("Item updated")
+        logger.info("Item updated")
       """
     When I deploy the rules file
     Then It should log "Item updated" within 5 seconds
@@ -239,7 +239,7 @@ Feature:  ensure_states
       rule "command received" do
         received_command DimmerOne, DimmerTwo
         run do |event|
-          logger.trace("Dimmers received command")
+          logger.info("Dimmers received command")
         end
       end
       sleep 1

--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -158,7 +158,7 @@ Feature: rule_language
       rule 'test' do
         on_start
         <block> { test }
-        delay 5.seconds
+        delay 1.seconds
         run { logger.info('This one works!') }
       end
       """
@@ -196,6 +196,7 @@ Feature: rule_language
     And It should log "RUBY.test" within 5 seconds
     And It should log "RUBY.<main>" within 5 seconds
 
+  @log_level_changed
   Scenario: Native java exceptions are handled during rule creation
     Given log level INFO
     And code in a rules file

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -168,7 +168,7 @@ def feature_installed?(feature)
 end
 
 def truncate_log
-  File.open(openhab_log, File::TRUNC)
+  File.open(openhab_log, File::TRUNC) {} # rubocop:disable Lint/EmptyBlock
 end
 
 def delete_conf_foo

--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -1,8 +1,28 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'open3'
+require 'pp'
 
 OPENHAB_VERSIONS = ['3.2.0', '3.3.0.M3'].freeze
+
+# Get list
+# rubocop: disable Metrics/MethodLength
+def features
+  stdout, stderr, status = Open3.capture3('bundle exec cucumber -d -f json')
+  raise stderr.to_s unless status.success?
+
+  matching_keywords = ['Scenario', 'Scenario Outline']
+  feature_json = JSON.parse(stdout)
+  feature_json.each_with_object([]) do |feature, feature_list|
+    uri = feature['uri']
+    feature['elements'].each do |element|
+      keyword = element['keyword']
+      feature_list << "#{uri}:#{element['line']}" if matching_keywords.include?(keyword)
+    end
+  end
+end
+# rubocop: enable Metrics/MethodLength
 
 # rubocop: disable Metrics/BlockLength
 # Disabled due to part of buid / potentially refactor into classes
@@ -19,11 +39,24 @@ namespace :github do
   end
 
   desc 'Test Matrix'
-  task :matrix do
+  task :matrix, [:runners] do |_, args|
+    runners = args[:runners].to_i
+    # puts "Creating matrix for #{runners} runners"
+    versions = OPENHAB_VERSIONS.length
+    runners_per_version = runners / versions
+    # puts "Splitting across #{versions} versions of OpenHAB with #{runners_per_version} runners per version"
+    feature_list = features
+    # shuffle feature list as often slower tests are in the same feature file
+    feature_list = feature_list.shuffle
+    features_per_runner = (feature_list.length / runners_per_version.to_f).ceil
+    # puts "#{feature_list.length} total features,  #{features_per_runner} features per runner"
+
     include_map = {}
-    include_map['include'] = Dir['features/**/*.feature'].map do |feature|
+    include_map['include'] = feature_list
+                             .each_slice(features_per_runner).to_a
+                             .map do |features|
       OPENHAB_VERSIONS.map do |version|
-        { feature: File.basename(feature, '.feature'), file: feature, openhab_version: version }
+        { features: features.join(' '), openhab_version: version }
       end
     end.flatten
     puts include_map.to_json

--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -51,14 +51,16 @@ namespace :github do
     features_per_runner = (feature_list.length / runners_per_version.to_f).ceil
     # puts "#{feature_list.length} total features,  #{features_per_runner} features per runner"
 
-    include_map = {}
-    include_map['include'] = feature_list
-                             .each_slice(features_per_runner).to_a
-                             .map do |features|
+    include_list = feature_list
+                   .each_slice(features_per_runner).to_a
+                   .map do |features|
       OPENHAB_VERSIONS.map do |version|
         { features: features.join(' '), openhab_version: version }
       end
     end.flatten
+
+    include_map = {}
+    include_map['include'] = include_list.map.with_index(1) { |element, i| element.merge({ index: i }) }
     puts include_map.to_json
   end
 

--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -4,7 +4,7 @@ require 'json'
 require 'open3'
 require 'pp'
 
-OPENHAB_VERSIONS = ['3.2.0', '3.3.0.M3'].freeze
+OPENHAB_VERSIONS = ['3.2.0', '3.3.0.M5'].freeze
 
 # Get list
 # rubocop: disable Metrics/MethodLength

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -312,7 +312,7 @@ namespace :openhab do
     puts 'Deleting any existing dumps'
     dump = Dir[dumps].each { |dump_file| rm dump_file }
 
-    karaf('dev:dump-create')
+    karaf('dev:dump-create --no-heap-dump')
 
     wait_for(30, 'Dump to be created') do
       Dir[dumps].any?


### PR DESCRIPTION
Resolve #310

* I started off from @boc-tothefuture's work.
* a @log_level_changed was missing in one of the scenarios in rule_language.feature. The scenario set the log level to INFO causing subsequent tests using trace log to fail
* added `index` to the matrix array and use it in openhab dump file. Previously it used the very long feature names which also contain illegal characters `:` and `/`

Other non-essential changes:
* Added --no-heap-dump to dev:dump-create to reduce the openhab dump file size (in the case of test failures)
* Updated test against 3.3.0.M5
* Replaced / simplified several ruby setup actions with ruby/setup-ruby + bundler-cache in workflow.yml
* Close the file handle in truncate_log - I'm not sure whether the file handles would've gotten closed anyway by Ruby's GC at the end of the method call, but it's better to be sure

This brings the test time down from 20m to 12m - 15m

I believe this should be ready to be merged