### PR TITLE
Jruby 9.4 (Ruby 3.x) tests

### DIFF
--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -2,9 +2,8 @@
 
 require 'json'
 require 'open3'
-require 'pp'
 
-OPENHAB_VERSIONS = ['3.2.0', '3.3.0'].freeze
+OPENHAB_VERSIONS = ['3.3.0', '3.4.0.M5+jruby9.4'].freeze
 
 # Get list
 # rubocop: disable Metrics/MethodLength


### PR DESCRIPTION
I've been playing with building the [automation bundle with jruby 9.4.0.0-SNAPSHOT](https://github.com/jimtng/openhab-addons/releases/tag/jruby-9.4-0.0.1)

https://github.com/jimtng/openhab-addons/commit/454238f920eca68539c4b5b3d99200a78aa2ca8d

This PR will be rebased once #606 is merged. In the mean time it contains the same changes that are included in #606 just so it can stand on its own and run the tests.

In this PR:
- Update the test matrix to use openhab 3.3.0.M7
- Add another variant to the test matrix that includes using a jruby 9.4 bundle
- several tweaks to the ci code to improve error recovery

I encountered a lot of "mysterious" errors where test scripts not executing after being added / loaded by the ScriptFileWatcher. Example: https://github.com/boc-tothefuture/openhab-jruby/runs/7014845491?check_suite_focus=true#step:6:211

The solution is to restart openhab. Even in this case, plenty of sleep time is needed after the restart. Some tests need to be retried by cucumber in order to pass because items' initial states were lost after a restart.

Restarting openhab isn't an ideal solution, so I'd like to figure out why this happened and how to avoid it.

I suspect these may be caused by the github runner running out of memory. Perhaps the java GC didn't have a chance to run with so many scripts loading and unloading, items added and removed, within one runner.

To solve this issue, this PR reduces the size of each runner by increasing the number of runners. It now runs in two batches due to the 20-runner limit.

~~Another measure to consider is adding swap for the github runner vm, or forcing a GC run every now and then.~~ Adding swap didn't make a difference. There was about 1gb of RAM free and zero swap use when the issue occurred.