### PR TITLE
ci(atomic_rule_write): create temp file in userdata/tmp

### DIFF
--- a/features/step_definitions/openhab_rules.rb
+++ b/features/step_definitions/openhab_rules.rb
@@ -30,7 +30,7 @@ def append_identifying_log_line_to_rule(code, uid)
 end
 
 def atomic_rule_write(rule_content, deploy_path)
-  temp_file = Tempfile.create(['cucumber_test', '.rb'])
+  temp_file = Tempfile.create(['cucumber_test', '.rb'], File.join(openhab_dir, 'userdata/tmp'))
   temp_file.write(rule_content)
   temp_file.close
 


### PR DESCRIPTION
This affects cucumber tests on my system, because my /tmp is on a separate mount. When using the Tempfile class and the tmp dir is in a different file system/mount, Openhab will load the file twice, resulting in incorrect operation.

Fix #595 