### PR TITLE
Jruby94 compatibility

### DIFF
--- a/docs/usage/triggers/generic.md
+++ b/docs/usage/triggers/generic.md
@@ -11,10 +11,10 @@ grand_parent: Usage
 
 `trigger` provides the ability to create a trigger type not already covered by the other methods.
 
-| Options       | Description                                                                                                   |
-| ------------- | ------------------------------------------------------------------------------------------------------------- |
-| type_uid      | A string representing the trigger type uid                                                                    |
-| configuration | a hash containing the configurations for the trigger, or a list of named keywords for the configuration items |
+| Options       | Description                                     |
+| ------------- | ----------------------------------------------- |
+| type_uid      | A string representing the trigger type uid      |
+| configuration | named keywords for the trigger's configurations |
 
 ## Example
 

--- a/features/generic_trigger.feature
+++ b/features/generic_trigger.feature
@@ -11,20 +11,6 @@ Feature:  generic_trigger
     And a deployed rule:
       """
       rule 'Execute rule when item is updated to any value' do
-        trigger 'core.ItemStateUpdateTrigger', { itemName: 'Switch1'}
-        run { logger.info("Switch1 Updated") }
-      end
-      """
-    When item "Switch1" state is changed to "ON"
-    Then It should log 'Switch1 Updated' within 5 seconds
-
-  Scenario: Use keyword arguments with trigger
-    Given items:
-      | type   | name    |
-      | Switch | Switch1 |
-    And a deployed rule:
-      """
-      rule 'Execute rule when item is updated to any value' do
         trigger 'core.ItemStateUpdateTrigger', itemName: 'Switch1'
         run { logger.info("Switch1 Updated") }
       end

--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -24,12 +24,12 @@ Feature: persistence
   Scenario: Make calls to various Persistence methods
     Given code in a rules file:
       """
-      @@last_update = nil
+      @last_update = nil
 
       rule 'record updated time' do
         updated Number1
         triggered do |item|
-          @@last_update = ZonedDateTime.now
+          @last_update = ZonedDateTime.now
           logger.info("#{item.name} = #{item.state} at: #{TimeOfDay.now}")
         end
       end

--- a/lib/openhab/core/thread_local.rb
+++ b/lib/openhab/core/thread_local.rb
@@ -33,7 +33,7 @@ module OpenHAB
       # @param [Hash] values Keys and values to set for running thread, if hash is nil no values are set
       #
       def thread_local(**values, &block)
-        ThreadLocal.thread_local(values, &block)
+        ThreadLocal.thread_local(**values, &block)
       end
     end
   end

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -88,6 +88,7 @@ module OpenHAB
             @item.__send__(method, *args, &block)
           end
         end
+        ruby2_keywords :method_missing if respond_to? :ruby2_keywords
 
         # .
         def respond_to_missing?(method, include_private = false)

--- a/lib/openhab/dsl/items/timed_command.rb
+++ b/lib/openhab/dsl/items/timed_command.rb
@@ -173,7 +173,7 @@ module OpenHAB
             def execute(_mod = nil, inputs = nil)
               OpenHAB::DSL.import_presets
               @semaphore.synchronize do
-                thread_local(@thread_locals) do
+                thread_local(**@thread_locals) do
                   logger.trace "Canceling implicit timer #{@timed_command_details.timer} for "\
                                "#{@timed_command_details.item.id}  because received event #{inputs}"
                   @timed_command_details.timer.cancel

--- a/lib/openhab/dsl/timers/timer.rb
+++ b/lib/openhab/dsl/timers/timer.rb
@@ -82,7 +82,7 @@ module OpenHAB
           OpenHAB::DSL.import_presets
           semaphore.synchronize do
             Timers.timer_manager.delete(self)
-            thread_local(@thread_locals) do
+            thread_local(**@thread_locals) do
               yield(self)
             end
           end

--- a/lib/openhab/log/logger.rb
+++ b/lib/openhab/log/logger.rb
@@ -212,7 +212,7 @@ module OpenHAB
               .then { |klass| java_klass(klass) }
               .then(&:name)
               .then { |name| filter_base_classes(name) }
-              .then { |name| name&.prepend('.') }
+              .then { |name| ".#{name}" unless name.nil? } # name is frozen in jruby 9.4
       end
 
       # Get the appropriate java class for the supplied klass if the supplied


### PR DESCRIPTION
This PR makes changes to the code base to be compatible with JRuby 9.4 / Ruby 3.x. It can be merged now because it is backwards compatible and should pass our current tests against jruby 9.3.

A separate draft PR will be created to add specific jruby 9.4 tests. That PR doesn't need to be merged yet until jruby 9.4 is in "beta".