### PR TITLE
fix(terse): improve automatic naming of terse rules

### DIFF
--- a/features/rule_language.feature
+++ b/features/rule_language.feature
@@ -91,12 +91,12 @@ Feature: rule_language
     And a rule
       """
       changed TestSwitch do
-        logger.trace("switch changed")
+        logger.trace("Rule {#{OpenHAB::DSL::Rules::Rule.script_rules.first.name}}")
       end
       """
     When I deploy the rule
     And item "TestSwitch" state is changed to "ON"
-    Then It should log 'switch changed' within 5 seconds
+    Then It should log 'Rule {TestSwitch changed}' within 5 seconds
 
   Scenario Outline: Triggers return an OpenHAB TriggerImpl object
     Given items:

--- a/lib/openhab/dsl/rules/terse.rb
+++ b/lib/openhab/dsl/rules/terse.rb
@@ -8,8 +8,8 @@ module OpenHAB
         %i[changed channel cron every updated received_command].each do |trigger|
           class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
             def #{trigger}(*args, name: nil, **kwargs, &block)                   # def changed(*args, name: nil, **kwargs, &block)
-              # if no name is given, just default to the name of the rules file  #   # if no name is given, just default to the name of the rules file
-              name ||= File.basename(caller_locations.last.path)                 #   name ||= File.basename(caller_locations.last.path)
+              name ||= infer_rule_name(#{trigger.inspect}, args, kwargs)         #   name ||= infer_rule_name(:changed, args, kwargs)
+              name ||= infer_rule_name_from_block(block)                         #   name ||= infer_rule_name_from_block(block)
               rule name do                                                       #   rule name do
                 #{trigger}(*args, **kwargs)                                      #     changed(*args, **kwargs)
                 run(&block)                                                      #     run(&block)
@@ -17,6 +17,38 @@ module OpenHAB
             end                                                                  # end
             module_function #{trigger.inspect}                                   # module_function :changed
           RUBY
+        end
+
+        private
+
+        # formulate a readable rule name such as "TestSwitch received command ON" if possible
+        def infer_rule_name(trigger, args, kwargs) # rubocop:disable Metrics
+          return unless %i[changed updated received_command].include?(trigger) &&
+                        args.length == 1 &&
+                        (kwargs.keys - %i[from to command]).empty?
+          return if kwargs[:from].is_a?(Enumerable)
+          return if kwargs[:to].is_a?(Enumerable)
+          return if kwargs[:command].is_a?(Enumerable)
+
+          trigger_name = trigger.to_s.tr('_', ' ')
+          name = if args.first.is_a?(GroupItem::GroupMembers) # rubocop:disable Style/CaseLikeIf === doesn't work with GenericItem
+                   "#{args.first.group.name}.members #{trigger_name}"
+                 elsif args.first.is_a?(GenericItem)
+                   "#{args.first.name} #{trigger_name}"
+                 end
+          return unless name
+
+          name += " from #{kwargs[:from].inspect}" if kwargs[:from]
+          name += " to #{kwargs[:to].inspect}" if kwargs[:to]
+          name += " #{kwargs[:command].inspect}" if kwargs[:command]
+          name
+        end
+
+        # get the block's source location, stripping some amount of common information
+        def infer_rule_name_from_block(block)
+          file = block.source_location.first.dup
+          file.sub!("#{org.openhab.core.OpenHAB.config_folder}/", '')
+          "#{file}:#{block.source_location.last}"
         end
       end
     end


### PR DESCRIPTION
construct a useful name if possible, otherwise use the full location of the execution block, including line number.