### PR TITLE
chore(rubocop): explicitly allow openhab globals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,15 @@ Style/Documentation:
   Enabled: false
 Style/HashSyntax:
   UseHashRocketsWithSymbolValues: true
+Style/GlobalVars:
+  AllowedVariables: # these globals are set by OpenHAB, and we can't change their name
+   - $actions
+   - $ir
+   - $rules
+   - $se
+   - $scriptExtension
+   - $things
+
 Gemspec/RequireMFA:
   Enabled: false
 

--- a/lib/openhab/core/entity_lookup.rb
+++ b/lib/openhab/core/entity_lookup.rb
@@ -73,9 +73,7 @@ module OpenHAB
         return if name.count('_') < 3
 
         name = name.tr('_', ':')
-        # rubocop: disable Style/GlobalVars
         $things.get(Java::OrgOpenhabCoreThing::ThingUID.new(name))
-        # rubocop: enable Style/GlobalVars
       end
 
       #
@@ -88,7 +86,7 @@ module OpenHAB
       def self.lookup_item(name)
         logger.trace("Looking up item(#{name})")
         name = name.to_s if name.is_a? Symbol
-        item = $ir.get(name) # rubocop: disable Style/GlobalVars
+        item = $ir.get(name)
         ItemProxy.new(item) unless item.nil?
       end
     end

--- a/lib/openhab/core/item_proxy.rb
+++ b/lib/openhab/core/item_proxy.rb
@@ -22,7 +22,7 @@ module OpenHAB
       # Lookup item from item registry
       #
       def __getobj__
-        $ir.get(@item_name) # rubocop:disable Style/GlobalVars
+        $ir.get(@item_name)
       end
     end
   end

--- a/lib/openhab/core/osgi.rb
+++ b/lib/openhab/core/osgi.rb
@@ -50,9 +50,7 @@ module OpenHAB
 
       # Get the OSGI Bundle for ScriptExtension Class
       def self.bundle
-        # rubocop: disable Style/GlobalVars
         @bundle ||= FrameworkUtil.getBundle($scriptExtension.class)
-        # rubocop: enable Style/GlobalVars
       end
       private_class_method :bundle
     end

--- a/lib/openhab/core/services.rb
+++ b/lib/openhab/core/services.rb
@@ -11,7 +11,6 @@ module OpenHAB
 
     # Get the OpenHAB automation manager
     # @return [AutomationManager] OpenHAB Automation manager
-    # rubocop:disable Style/GlobalVars
     def self.automation_manager
       $scriptExtension.get('automationManager')
     end
@@ -21,6 +20,5 @@ module OpenHAB
     def self.rule_registry
       $scriptExtension.get('ruleRegistry')
     end
-    # rubocop:enable Style/GlobalVars
   end
 end

--- a/lib/openhab/dsl/actions.rb
+++ b/lib/openhab/dsl/actions.rb
@@ -29,9 +29,7 @@ module OpenHAB
       # @return [Object] OpenHAB action
       #
       def actions(scope, thing_uid)
-        # rubocop: disable Style/GlobalVars
         $actions.get(scope, thing_uid)
-        # rubocop: enable Style/GlobalVars
       end
 
       #
@@ -43,9 +41,7 @@ module OpenHAB
       #
       def actions_for_thing(thing_uid)
         thing_uid = thing_uid.to_s
-        # rubocop: disable Style/GlobalVars
         action_keys = $actions.action_keys
-        # rubocop: enable Style/GlobalVars
         logger.trace("Registered actions: '#{action_keys}' for thing '#{thing_uid}'")
         action_keys.map { |action_key| action_key.split('-', 2) }
                    .select { |action_pair| action_pair.last == thing_uid }

--- a/lib/openhab/dsl/group.rb
+++ b/lib/openhab/dsl/group.rb
@@ -46,7 +46,7 @@ module OpenHAB
 
         # explicit conversion to array
         def to_a
-          $ir.items.grep(org.openhab.core.items.GroupItem) # rubocop:disable Style/GlobalVars
+          $ir.items.grep(org.openhab.core.items.GroupItem)
         end
       end
     end

--- a/lib/openhab/dsl/items/item_registry.rb
+++ b/lib/openhab/dsl/items/item_registry.rb
@@ -39,14 +39,14 @@ module OpenHAB
         # @param name [String] Item name to check
         # @return [Boolean] true if the item exists, false otherwise
         def include?(name)
-          !$ir.getItems(name).empty? # rubocop: disable Style/GlobalVars
+          !$ir.getItems(name).empty?
         end
         alias key? include?
 
         # Explicit conversion to array
         # @return [Array]
         def to_a
-          $ir.items.to_a # rubocop:disable Style/GlobalVars
+          $ir.items.to_a
         end
       end
     end

--- a/lib/openhab/dsl/items/timed_command.rb
+++ b/lib/openhab/dsl/items/timed_command.rb
@@ -177,10 +177,8 @@ module OpenHAB
                   logger.trace "Canceling implicit timer #{@timed_command_details.timer} for "\
                                "#{@timed_command_details.item.id}  because received event #{inputs}"
                   @timed_command_details.timer.cancel
-                  # rubocop: disable Style/GlobalVars
                   # Disabled due to OpenHAB design
                   $scriptExtension.get('ruleRegistry').remove(@timed_command_details.rule_uid)
-                  # rubocop: enable Style/GlobalVars
                   TimedCommand.timed_commands.delete(@timed_command_details.item)
                   if @block
                     logger.trace 'Executing user supplied block on timed command cancelation'

--- a/lib/openhab/dsl/monkey_patch/actions/script_thing_actions.rb
+++ b/lib/openhab/dsl/monkey_patch/actions/script_thing_actions.rb
@@ -12,7 +12,7 @@ module OpenHAB
         #
         # MonkeyPatching ScriptThingActions
         #
-        class << $actions # rubocop:disable Style/GlobalVars
+        class << $actions
           field_reader :THING_ACTIONS_MAP
 
           #

--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -148,7 +148,7 @@ module OpenHAB
         def add_rule(rule)
           base_uid = rule.uid
           duplicate_index = 1
-          while $rules.get(rule.uid) # rubocop:disable Style/GlobalVars
+          while $rules.get(rule.uid)
             duplicate_index += 1
             rule.uid = "#{base_uid} (#{duplicate_index})"
           end

--- a/lib/openhab/dsl/things.rb
+++ b/lib/openhab/dsl/things.rb
@@ -108,7 +108,7 @@ module OpenHAB
         # @return Thing specified by name/UID or nil if name/UID does not exist in thing registry
         def [](uid)
           uid = generate_thing_uid(uid) unless uid.is_a?(org.openhab.core.thing.ThingUID)
-          thing = $things.get(uid) # rubocop: disable Style/GlobalVars
+          thing = $things.get(uid)
           return unless thing
 
           logger.trace("Retrieved Thing(#{thing}) from registry for uid: #{uid}")
@@ -119,7 +119,7 @@ module OpenHAB
 
         # explicit conversion to array
         def to_a
-          $things.getAll.map { |thing| Thing.new(thing) } # rubocop: disable Style/GlobalVars
+          $things.getAll.map { |thing| Thing.new(thing) }
         end
 
         private


### PR DESCRIPTION
instead of having to disable it at each usage