### PR TITLE
fix(rules): fix reloading of rules

### DIFF
--- a/lib/openhab/dsl/rules/rule.rb
+++ b/lib/openhab/dsl/rules/rule.rb
@@ -89,7 +89,7 @@ module OpenHAB
           rule = AutomationRule.new(config: config)
           Rule.script_rules << rule
           added_rule = add_rule(rule)
-          added_rule.actions.first.id = 'script'
+          # add config so that MainUI can show the script
           added_rule.actions.first.configuration.put('type', 'application/x-ruby')
           added_rule.actions.first.configuration.put('script', script)
 


### PR DESCRIPTION
fixes #620

we were changing the ID of the action after it was registered, so
when it unregistered it couldn't find its handler, and was orphaning
it. only to reuse the old handler on the reload because the id hadn't
been changed yet